### PR TITLE
Implement cardinality-constrained regression

### DIFF
--- a/card.py
+++ b/card.py
@@ -1,9 +1,8 @@
 ### First snippet
 from sklearn import datasets
 from sklearn.model_selection import train_test_split
-from sklearn.preprocessing import StandardScaler
 
-from gurobi_optimods.regression import CardinalityConstrainedRegression, LADRegression
+from gurobi_optimods.regression import CardinalityConstrainedRegression
 
 # Load the diabetes dataset
 diabetes = datasets.load_diabetes()
@@ -37,7 +36,7 @@ fig.tight_layout()
 
 import pandas as pd
 import matplotlib.pyplot as plt
-from sklearn.linear_model import Lasso, Ridge, LinearRegression
+from sklearn.linear_model import Lasso
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 
 models = [

--- a/card.py
+++ b/card.py
@@ -1,0 +1,79 @@
+### First snippet
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import StandardScaler
+
+from gurobi_optimods.regression import CardinalityConstrainedRegression, LADRegression
+
+# Load the diabetes dataset
+diabetes = datasets.load_diabetes()
+
+# Split data for fit assessment
+X_train, X_test, y_train, y_test = train_test_split(
+    diabetes["data"], diabetes["target"], random_state=982, test_size=0.1
+)
+
+# Fit model and obtain predictions
+ccr = CardinalityConstrainedRegression(k=10)
+ccr.fit(X_train, y_train, silent=False)
+y_pred = ccr.predict(X_test)
+
+### Second snippet
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.linear_model import Lasso
+
+lasso = Lasso(alpha=0.1)
+lasso.fit(X_train, y_train)
+coefficients = pd.DataFrame(
+    data={"Lasso": lasso.coef_, "CCR": ccr.coef_}, index=diabetes["feature_names"]
+)
+
+fig = plt.figure(figsize=(8, 4))
+coefficients.plot.bar(ax=plt.gca())
+fig.tight_layout()
+
+### Hyperparameter optimization for CCR
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.linear_model import Lasso, Ridge, LinearRegression
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+
+models = [
+    {"k": k, "regressor": CardinalityConstrainedRegression(k=k)} for k in range(2, 10)
+]
+
+for model in models:
+    model["regressor"].fit(X_train, y_train, silent=True)
+    y_pred = model["regressor"].predict(X_train)
+    model["mae-train"] = mean_absolute_error(y_pred, y_train)
+    model["mse-train"] = mean_squared_error(y_pred, y_train)
+    y_pred = model["regressor"].predict(X_test)
+    model["mae-test"] = mean_absolute_error(y_pred, y_test)
+    model["mse-test"] = mean_squared_error(y_pred, y_test)
+
+pd.DataFrame(models).plot.line(x="k", y=["mae-test", "mae-train"])
+
+### Hyperparameter optimization for Lasso
+
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+
+models = [
+    {"alpha": alpha, "regressor": Lasso(alpha=alpha)}
+    for alpha in np.linspace(0.001, 1.0)
+]
+
+for model in models:
+    model["regressor"].fit(X_train, y_train)
+    y_pred = model["regressor"].predict(X_train)
+    model["mae-train"] = mean_absolute_error(y_pred, y_train)
+    model["mse-train"] = mean_squared_error(y_pred, y_train)
+    y_pred = model["regressor"].predict(X_test)
+    model["mae-test"] = mean_absolute_error(y_pred, y_test)
+    model["mse-test"] = mean_squared_error(y_pred, y_test)
+
+pd.DataFrame(models).plot.line(x="alpha", y=["mae-test", "mae-train"])

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -20,7 +20,7 @@ API Reference
    :members: solve_qubo
 
 .. automodule:: gurobi_optimods.regression
-   :members: LADRegression
+   :members: LADRegression, CardinalityConstrainedRegression
 
 .. automodule:: gurobi_optimods.workforce
    :members: solve_workforce_scheduling

--- a/docs/source/gallery.rst
+++ b/docs/source/gallery.rst
@@ -12,6 +12,11 @@ The OptiMods Gallery
         :text-align: center
         :img-top: mods/figures/bipartite-matching-example.png
 
+    .. grid-item-card:: Cardinality Constrained Regression
+        :link: mods/card-regression
+        :link-type: doc
+        :text-align: center
+
     .. grid-item-card:: Stigler Diet Problem
         :link: mods/diet
         :link-type: doc
@@ -60,6 +65,7 @@ The OptiMods Gallery
    :hidden:
 
    mods/bipartite-matching
+   mods/card-regression
    mods/diet
    mods/l1-regression
    mods/min-cost-flow

--- a/docs/source/mods/card-regression.rst
+++ b/docs/source/mods/card-regression.rst
@@ -1,0 +1,125 @@
+Cardinality Constrained Regression
+==================================
+
+- Present this in contrast to :code:`sklearn.linear_model.Lasso`.
+- Cardinality constrained regression provides a stricter approach to model regularization.
+- Instead of including a weighted objective term which tries to avoid unnecessary large coefficients in a model, cardinality constrained regression enforced a limit on the number of non-zero coefficients.
+- Result is a model with limited complexity: explainable AI, woohoo!
+
+Problem Specification
+---------------------
+
+See sklearn `Lasso <https://scikit-learn.org/stable/modules/linear_model.html#lasso>`_ for general explanation.
+
+.. tabs::
+
+    .. tab:: Loss Function
+
+        :code:`CardConstrainedRegression` fits a linear model with coefficients :math:`w` to minimize the sum of absolute errors.
+
+        .. math::
+
+            \begin{alignat}{2}
+            \min_w \quad        & \lvert Xw - y \rvert \\
+            \mbox{s.t.} \quad   & {\lvert x \rvert}_0 \le k \\
+            \end{alignat}
+
+    .. tab:: Optimization Model
+
+        To model the L1 regression loss function using linear programming, we need to introduce a number of auxiliary variables. Here :math:`I` is the set of data points and :math:`J` the set of fields. Response values :math:`y_i` are predicted from predictor values :math:`x_{ij}` by fitting coefficients :math:`w_j`. To handle the absolute value, non-negative variables :math:`u_i` and :math:`v_i` are introduced. Additionally, binary variables :math:`b_i` track the number of non-zero coefficients.
+
+        .. math::
+
+            \begin{alignat}{2}
+            \min \quad        & \sum_i u_i + v_i \\
+            \mbox{s.t.} \quad & \sum_j w_j x_{ij} + u_i - v_i = y_i \quad & \forall i \in I \\
+                              & -M b_j \le w_j \le M b_j           \quad & \forall j \in J \\
+                              & \sum_j b_j \le k \\
+                              & u_i, v_i \ge 0                     \quad & \forall i \in I \\
+                              & w_j \,\, \text{free}               \quad & \forall j \in J \\
+            \end{alignat}
+
+Code
+----
+
+.. testcode:: card_regression
+
+    from sklearn import datasets
+    from sklearn.model_selection import train_test_split
+
+    from gurobi_optimods.regression import CardinalityConstrainedRegression
+
+    # Load the diabetes dataset
+    diabetes_X, diabetes_y = datasets.load_diabetes(return_X_y=True)
+
+    # Split data for fit assessment
+    X_train, X_test, y_train, y_test = train_test_split(
+        diabetes_X, diabetes_y, random_state=42
+    )
+
+    # Create and fit parameterised model, including an intercept
+    # but with at most two non-zero coefficients.
+    reg = CardinalityConstrainedRegression(k=2)
+    reg.fit(X_train, y_train)
+    y_pred = reg.predict(X_test)
+
+.. testoutput:: card_regression
+    :hide:
+
+    ...
+    Optimize a model with 332 rows, 352 columns and 3982 nonzeros
+    ...
+    Optimal solution found (tolerance 1.00e-04)
+    Best objective 5.67...
+
+
+The model is solved as a MIP by Gurobi. Logs provided for interested parties:
+
+.. collapse:: View Gurobi logs
+
+    .. code-block:: text
+
+        Gurobi Optimizer version 10.0.1 build v10.0.1rc0 (mac64[x86])
+
+        CPU model: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
+        Thread count: 4 physical cores, 8 logical processors, using up to 8 threads
+
+        Optimize a model with 332 rows, 352 columns and 3982 nonzeros
+        Model fingerprint: 0x3e2736be
+        Model has 331 quadratic objective terms
+        Model has 10 SOS constraints
+        Variable types: 342 continuous, 10 integer (10 binary)
+        Coefficient statistics:
+          Matrix range     [6e-05, 1e+00]
+          Objective range  [0e+00, 0e+00]
+          QObjective range [2e+00, 2e+00]
+          Bounds range     [1e+00, 1e+00]
+          RHS range        [8e+00, 3e+02]
+        Presolve time: 0.00s
+        Presolved: 332 rows, 352 columns, 3982 nonzeros
+        Presolved model has 10 SOS constraint(s)
+        Presolved model has 331 quadratic objective terms
+        Variable types: 342 continuous, 10 integer (10 binary)
+
+        Root relaxation: objective 4.581241e+06, 686 iterations, 0.02 seconds (0.02 work units)
+
+            Nodes    |    Current Node    |     Objective Bounds      |     Work
+         Expl Unexpl |  Obj  Depth IntInf | Incumbent    BestBd   Gap | It/Node Time
+
+             0     0 4581241.43    0    8          - 4581241.43      -     -    0s
+        H    0     0                    6370343.1269 4581241.43  28.1%     -    0s
+        H    0     0                    6220498.1405 4581241.43  26.4%     -    0s
+             0     0 4584952.94    0    8 6220498.14 4584952.94  26.3%     -    0s
+             0     2 4584952.94    0    8 6220498.14 4584952.94  26.3%     -    0s
+        *    5     6               2    6173920.5974 4819424.92  21.9%  10.2    0s
+        *   12    10               3    6078925.9446 4878409.47  19.7%   9.0    0s
+        H   34     8                    6028487.5605 5253130.81  12.9%   7.9    0s
+        *   35     8               6    5673934.6855 5253130.81  7.42%   8.1    0s
+
+        Explored 57 nodes (1028 simplex iterations) in 0.12 seconds (0.14 work units)
+        Thread count was 8 (of 8 available processors)
+
+        Solution count 6: 5.67393e+06 6.02849e+06 6.07893e+06 ... 6.37034e+06
+
+        Optimal solution found (tolerance 1.00e-04)
+        Best objective 5.673934685517e+06, best bound 5.673934685517e+06, gap 0.0000%

--- a/src/gurobi_optimods/regression.py
+++ b/src/gurobi_optimods/regression.py
@@ -67,3 +67,50 @@ class LADRegression(RegressionBase):
             model.optimize()
             self.intercept_ = intercept.X
             self.coef_ = coeff.X
+
+
+class CardinalityConstrainedRegression(RegressionBase):
+    """Cardinality constrained (limit #nonzeros) least squares regression"""
+
+    def __init__(self, k):
+        super().__init__()
+        self.cardinality = k
+
+    @optimod()
+    def fit(self, X_train, y_train, *, create_env):
+        """Fit the model to training data.
+
+        :param X_train: Training set feature values
+        :type X_train: :class:`np.array`
+        :param y_train: Training set output values
+        :type y_train: :class:`np.array`
+        """
+
+        # Metadata about the input data
+        records, n_features_in = X_train.shape
+
+        with create_env() as env, gp.Model(env=env) as model:
+
+            # Create unbounded variables for each column coefficient, and
+            # error terms. Keep intercept separate.
+            intercept = model.addVar(lb=-GRB.INFINITY, name="intercept")
+            iszero = model.addMVar(n_features_in, vtype=GRB.BINARY, name="iszero")
+            coeff = model.addMVar(n_features_in, lb=-GRB.INFINITY, name="coeff")
+            error = model.addMVar(records, name="error")
+
+            # Create linear relationships with deviation variables
+            relation = (X_train * coeff).sum(axis=1) + intercept + error
+            model.addConstr(relation == y_train, name="fit")
+
+            # Constrain model cardinality
+            for i in range(n_features_in):
+                model.addSOS(GRB.SOS_TYPE1, [coeff[i].item(), iszero[i].item()])
+            model.addConstr((1.0 - iszero).sum() <= self.cardinality)
+
+            # Minimize sum of squares of deviations
+            model.setObjective(error @ error, sense=GRB.MINIMIZE)
+
+            # Solve and store results
+            model.optimize()
+            self.intercept_ = intercept.X
+            self.coef_ = coeff.X

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from gurobi_optimods.regression import LADRegression
+from gurobi_optimods.regression import LADRegression, CardinalityConstrainedRegression
 
 
 class TestLADRegression(unittest.TestCase):
@@ -28,6 +28,38 @@ class TestLADRegression(unittest.TestCase):
         y_train = np.random.random((100))
         reg = LADRegression()
         reg.fit(X_train, y_train)
+
+        # Check predictions are the right shape
+        y_pred = reg.predict(np.random.random((30, 5)))
+        self.assertEqual(y_pred.shape, (30,))
+
+
+class TestCardinalityConstrainedRegression(unittest.TestCase):
+    def test_two_points(self):
+        # Unconstrained least-squares through two points in 2D is a perfect fit
+        X_train = np.array([[1.0], [3.0]])
+        y_train = np.array([2.0, 6.0])
+        reg = CardinalityConstrainedRegression(k=1)
+        reg.fit(X_train, y_train)
+
+        # Known fit
+        assert_allclose(reg.intercept_, 0.0)
+        assert_allclose(reg.coef_, np.array([2.0]))
+
+        # Test predictions
+        y_pred = reg.predict(np.array([[1.0], [2.0], [3.0]]))
+        assert_allclose(y_pred, np.array([2.0, 4.0, 6.0]))
+
+    def test_random_constrained(self):
+        # Plug in some random data and check shape consistency.
+        # Verify that cardinality constraint is respected
+        X_train = np.random.random((100, 5))
+        y_train = np.random.random((100))
+        reg = CardinalityConstrainedRegression(k=2)
+        reg.fit(X_train, y_train)
+
+        # Coefficient properties
+        self.assertLessEqual(np.count_nonzero(reg.coef_), 2)
 
         # Check predictions are the right shape
         y_pred = reg.predict(np.random.random((30, 5)))

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -5,6 +5,8 @@ from numpy.testing import assert_allclose
 
 from gurobi_optimods.regression import LADRegression, CardinalityConstrainedRegression
 
+from .utils import large_model
+
 
 class TestLADRegression(unittest.TestCase):
     def test_two_points(self):
@@ -50,11 +52,12 @@ class TestCardinalityConstrainedRegression(unittest.TestCase):
         y_pred = reg.predict(np.array([[1.0], [2.0], [3.0]]))
         assert_allclose(y_pred, np.array([2.0, 4.0, 6.0]))
 
+    @large_model
     def test_random_constrained(self):
         # Plug in some random data and check shape consistency.
         # Verify that cardinality constraint is respected
-        X_train = np.random.random((100, 5))
-        y_train = np.random.random((100))
+        X_train = np.random.random((200, 5))
+        y_train = np.random.random((200))
         reg = CardinalityConstrainedRegression(k=2)
         reg.fit(X_train, y_train)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,8 @@
+"""
+Test of gurobi_optimods.utils, not to be confused with utilities for testing
+found in tests/utils.py
+"""
+
 import io
 import os
 import tempfile

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,29 @@
+"""
+Testing utilities, not to be confused with unit tests of gurobi_optimods.utils
+found in tests/test_utils.py
+"""
+
+import functools
+import unittest
+
+import gurobipy as gp
+from gurobipy import GRB
+
+
+def large_model(test_item):
+    """Decorator for tests which create large models (i.e. those that the pip
+    demo license does not cover). If a decorated test fails due to license limits,
+    it will be skipped."""
+
+    @functools.wraps(test_item)
+    def skip_wrapper(*args, **kwargs):
+        try:
+            test_item(*args, **kwargs)
+        except gp.GurobiError as ge:
+            # Skip the test if the failure was due to licensing
+            if ge.errno == GRB.Error.SIZE_LIMIT_EXCEEDED:
+                raise unittest.SkipTest("Size-limited Gurobi license")
+            # Otherwise, let the error go through as-is
+            raise
+
+    return skip_wrapper


### PR DESCRIPTION
### Description

Reinstates the cardinality-constrained regression mod and continue hacking. May need a better dataset to justify its existence. Closes #8.

### Checklist
<!-- go over following points. check them with an `x` if they are completed, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once) -->

- Implementation:
  - [ ] Implementation of the Mod in the `gurobi_optimods` installable package
  - [ ] Tests for the Mod implementation in `tests/`
  - [ ] Docstrings for public API, correctly linked using sphinx-autodoc
- Documentation page:
  - [ ] Problem specification with description tab and optimzation model tab
  - [ ] Example of the input data format (use `gurobi_optimods.datasets` for loading data)
  - [ ] Runnable code example
  - [ ] Presentation of solutions

**Have a nice day!**