### PR TITLE
Add a time limit parameter to the mod decorator

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -99,7 +99,8 @@ def process_signature(app, what, name, obj, options, signature, return_annotatio
         if "create_env" not in signature:
             raise ValueError(f"Decorated mod {name} does not accept create_env")
         new_signature = signature.replace(
-            "create_env", "verbose=True, logfile=None, solver_params=None"
+            "create_env",
+            "verbose=True, logfile=None, time_limit=None, solver_params=None",
         )
         print(f"Modified signature of {name}")
         return new_signature, return_annotation
@@ -113,6 +114,9 @@ boilerplate = """
 
     **logfile** : :class:`python:str`, optional
         Write all mod output to the given file path
+
+    **time_limit** : :class:`python:float`
+        Solver time limit in seconds (default no limit)
 
     **solver_params** : :class:`python:dict`, optional
         Gurobi parameters to be passed to the solver

--- a/docs/source/mods/opf/opf.rst
+++ b/docs/source/mods/opf/opf.rst
@@ -101,20 +101,13 @@ argument specifies otherwise.
     ...
 
 ACOPF and `Branch-Switching`_ models are most often very hard to solve to
-optimality. For this reason, it is best to pass specific solver settings such
-as, e.g., a `TimeLimit
-<https://www.gurobi.com/documentation/current/refman/timelimit.html>`_. This can
-be done by using the ``solver_params`` argument. For a full list of all Gurobi
-parameters please refer to `our documentation
-<https://www.gurobi.com/documentation/current/refman/parameter_descriptions.html>`_.
+optimality. For this reason, it is recommended to specify a solver time limit
+using the ``time_limit`` parameter. If the problem has not been solved to
+optimality within the time limit, the best known solution will be returned.
 
 .. testcode:: opf
 
-    result = opf.solve_opf(
-        case,
-        opftype="AC",
-        solver_params={"TimeLimit": 60}
-    )
+    result = opf.solve_opf(case, opftype="AC", time_limit=60)
 
 .. testoutput:: opf
     :hide:

--- a/src/gurobi_optimods/qubo.py
+++ b/src/gurobi_optimods/qubo.py
@@ -53,7 +53,7 @@ def callback(model, where):
 
 
 @optimod()
-def solve_qubo(coeff_matrix, time_limit=GRB.INFINITY, *, create_env) -> QuboResult:
+def solve_qubo(coeff_matrix, *, create_env) -> QuboResult:
     """
     Solve a quadratic unconstrained binary optimization (QUBO) problem, i.e.,
     minimize quadratic function :math:`x'Qx` defined by coefficient matrix
@@ -63,8 +63,6 @@ def solve_qubo(coeff_matrix, time_limit=GRB.INFINITY, *, create_env) -> QuboResu
     ----------
     coeff_matrix : spmatrix
         Quadratic coefficient matrix
-    time_limit : float
-        Time limit in seconds (optional, default no limit)
 
     Returns
     -------
@@ -81,7 +79,7 @@ def solve_qubo(coeff_matrix, time_limit=GRB.INFINITY, *, create_env) -> QuboResu
 
     n = shape[0]
 
-    params = {"TimeLimit": time_limit, "LogToConsole": 0}
+    params = {"LogToConsole": 0}
 
     with create_env(params=params) as env, gp.Model(env=env) as model:
         x = model.addMVar(n, vtype=GRB.BINARY)

--- a/src/gurobi_optimods/utils.py
+++ b/src/gurobi_optimods/utils.py
@@ -50,6 +50,7 @@ def _mod_context(
     mod_logger: logging.Logger,
     log_to_console: bool,
     log_to_file: Optional[str],
+    time_limit: Optional[float],
     user_params: Optional[Dict],
 ):
     if not log_to_console and log_to_file:
@@ -82,6 +83,12 @@ def _mod_context(
         grb_logger.setLevel(logging.INFO)
         grb_logger.addHandler(fh)
 
+    if user_params is None:
+        user_params = {}
+
+    if time_limit is not None:
+        user_params["TimeLimit"] = float(time_limit)
+
     # Environment factory for decorated mod to use
     def create_env(params=None):
         final_params = {}
@@ -112,12 +119,18 @@ def optimod(mod_logger=None):
     def optimod_decorator(func):
         @functools.wraps(func)
         def optimod_decorated(
-            *args, verbose=True, logfile=None, solver_params=None, **kwargs
+            *args,
+            verbose=True,
+            logfile=None,
+            time_limit=None,
+            solver_params=None,
+            **kwargs,
         ):
             with _mod_context(
                 mod_logger=mod_logger,
                 log_to_console=verbose,
                 log_to_file=logfile,
+                time_limit=time_limit,
                 user_params=solver_params,
             ) as create_env:
                 try:

--- a/tests/test_qubo.py
+++ b/tests/test_qubo.py
@@ -55,3 +55,12 @@ class TestQubo(unittest.TestCase):
         result = solve_qubo(Q)
         self.assertEqual(result.objective_value, -2)
         assert_array_equal(result.solution, np.array([1, 0, 1]))
+
+    def test_large_matrix_time_limit(self):
+        # Should get a solution quickly, but take forever without a time limit.
+        # Largest model size solvable by the trial license.
+        Q = sp.random(200, 200, 0.5)
+        Q = sp.coo_matrix((Q.data - 0.5, (Q.row, Q.col)))
+        result = solve_qubo(Q, time_limit=0.5)
+        self.assertLess(result.objective_value, 0.0)
+        self.assertEqual(result.solution.shape, (200,))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,6 +117,17 @@ class TestOptimodDecorator(unittest.TestCase):
                 )
                 raise
 
+    def test_time_limit(self):
+        # Make time limit is a first class parameter for all mods
+
+        with redirect_stdout(io.StringIO()) as buffer_stdout, redirect_stderr(
+            io.StringIO()
+        ) as buffer_stderr:
+            self.mod(time_limit=10)
+
+        self.assertIn("Set parameter TimeLimit to value 10", buffer_stdout.getvalue())
+        self.assertEqual(buffer_stderr.getvalue(), "")
+
 
 class TestOverrideParams(unittest.TestCase):
     def test_mod_override_outputflag(self):


### PR DESCRIPTION
Closes #110

Add a `time_limit` parameter to the optimod decorator. It's a simple change, essentially a shortcut for `solver_params={"Timelimit": ...}`.