### PR TITLE
OPF bugfix in compute_voltage_angles

### DIFF
--- a/src/gurobi_optimods/opf/grbformulator.py
+++ b/src/gurobi_optimods/opf/grbformulator.py
@@ -432,6 +432,9 @@ def compute_voltage_angles(alldata, result):
     :type result: dict
     """
 
+    # FIXME this code assumes bus.nodeID == busindex (NOT TRUE!)
+    # Need to use the 'count map' (or fix the issue at the source)
+
     # After setting all voltage magnitudes, we can compute the voltage angle
     # Set voltage angle of reference bus to 0 (this is arbitrary)
     buses = alldata["buses"]

--- a/src/gurobi_optimods/opf/grbformulator.py
+++ b/src/gurobi_optimods/opf/grbformulator.py
@@ -423,77 +423,95 @@ def fill_result_fields(alldata, model, opftype, result):
 
 def compute_voltage_angles(alldata, result):
     """
-    Helper function to compute voltage angles out of previously computed
-    voltage magnitudes for a given AC OPF solution
+    Helper function to compute voltage angles out of previously computed voltage
+    magnitudes for a given AC OPF solution.
 
-    :param alldata: Main dictionary holding all necessary data
-    :type alldata: dict
-    :param result: Result dictionary which is constructed for the user
-    :type result: dict
+    Starting from an arbitrary reference bus, the walks through all buses in a
+    connected order (by branches) so that voltage angle for a new bus can be
+    computed from a known bus. The voltage angle of the reference bus in set to
+    zero (arbitrary).
+
+    Computation for a new bus based on a known bus (where k = "from" m = "to":
+
+        cvar[km] = (voltage mag at k) * (voltage mag at m) * cos(thetak - thetam)
+
+    TODO will fail if the network is disconnected
+
+    TODO this could be implemented more simply
     """
 
-    # FIXME this code assumes bus.nodeID == busindex (NOT TRUE!)
-    # Need to use the 'count map' (or fix the issue at the source)
-
-    # After setting all voltage magnitudes, we can compute the voltage angle
-    # Set voltage angle of reference bus to 0 (this is arbitrary)
+    IDtoCountmap = alldata["IDtoCountmap"]
+    # for k, v in IDtoCountmap.items():
+    # assert k == v
     buses = alldata["buses"]
     branches = alldata["branches"]
-    busindex = alldata["refbus"]
     cvar = alldata["LP"]["cvar"]
+
+    # Start from the reference bus, set voltage angle to zero
+    busindex = alldata["refbus"]
     result["bus"][busindex]["Va"] = 0
-    # Next, compute the angle of all other buses starting from the reference bus
-    # k = "from" m = "to"
-    # cvar[km] = (voltage mag at k) * (voltage mag at m) * cos(thetak - thetam)
+
+    # Initial network search state. Note: all references to buses use the
+    # 'count' not the nodeID
     busesdone = {busindex}
     busesnext = set()
     for branchindex in buses[busindex].frombranchids.values():
         b = branches[branchindex]
-        # Already computed angle is always at first place of tuple
-        busesnext.add((b.f, b.t, branchindex, "f"))
+        busesnext.add((IDtoCountmap[b.f], IDtoCountmap[b.t], branchindex, "f"))
     for branchindex in buses[busindex].tobranchids.values():
         b = branches[branchindex]
-        # Already computed angle is always at first place of tuple
-        busesnext.add((b.t, b.f, branchindex, "t"))
+        busesnext.add((IDtoCountmap[b.t], IDtoCountmap[b.f], branchindex, "t"))
 
     while len(busesdone) != alldata["numbuses"]:
-        # Get a new bus
-        nextb = busesnext.pop()
-        while nextb[1] in busesdone:
-            nextb = busesnext.pop()
-        nextbusindex = nextb[1]
+        # Get a bus from the queue. This bus does not yet have it's voltage
+        # angle calculated, but is connected to a bus with a known voltage angle
+        # by the given branch.
+        knownbusindex, nextbusindex, branchindex, relationship = busesnext.pop()
+        while nextbusindex in busesdone:
+            knownbusindex, nextbusindex, branchindex, relationship = busesnext.pop()
         nextbus = buses[nextbusindex]
-        knownbusindex = nextb[0]
-        buses[knownbusindex]
+        knownbus = buses[knownbusindex]
+        assert knownbusindex in busesdone
+        branch = branches[branchindex]
+        if relationship == "f":
+            assert branch.f == knownbus.nodeID
+            assert branch.t == nextbus.nodeID
+        else:
+            assert relationship == "t"
+            assert branch.t == knownbus.nodeID
+            assert branch.f == nextbus.nodeID
+
+        # Compute the voltage angle of the next bus based on the known bus
         if alldata["doiv"]:
             # For IV, we filled the values manually so they are not Gurobi variables
-            cvarval = cvar[branches[nextb[2]]]
+            cvarval = cvar[branch]
         else:
-            cvarval = cvar[branches[nextb[2]]].X
-
+            cvarval = cvar[branch].X
         tmp = cvarval / (
             result["bus"][nextbusindex]["Vm"] * result["bus"][knownbusindex]["Vm"]
         )
         # Safe guard to avoid slightly being out of [-1,1] for numerical reasons
         tmp = max(-1, min(1, tmp))
         res = math.acos(tmp)
-        if nextb[3] == "f":
+        if relationship == "f":
             res -= result["bus"][knownbusindex]["Va"]
             res *= -1
         else:
             res += result["bus"][knownbusindex]["Va"]
         result["bus"][nextbusindex]["Va"] = res
-        busesdone.add(nextbusindex)
 
+        # Update search state
+        busesdone.add(nextbusindex)
         for branchindex in nextbus.frombranchids.values():
             b = branches[branchindex]
-            # Only add if bus is not done already
-            if b.t not in busesdone:
-                busesnext.add((b.f, b.t, branchindex, "f"))
+            assert b.f == nextbus.nodeID
+            if IDtoCountmap[b.t] not in busesdone:
+                busesnext.add((IDtoCountmap[b.f], IDtoCountmap[b.t], branchindex, "f"))
         for branchindex in nextbus.tobranchids.values():
             b = branches[branchindex]
-            if b.f not in busesdone:
-                busesnext.add((b.t, b.f, branchindex, "t"))
+            assert b.t == nextbus.nodeID
+            if IDtoCountmap[b.f] not in busesdone:
+                busesnext.add((IDtoCountmap[b.t], IDtoCountmap[b.f], branchindex, "t"))
 
 
 def fill_violations_fields(alldata, opftype, result):

--- a/src/gurobi_optimods/opf/grbformulator.py
+++ b/src/gurobi_optimods/opf/grbformulator.py
@@ -441,8 +441,6 @@ def compute_voltage_angles(alldata, result):
     """
 
     IDtoCountmap = alldata["IDtoCountmap"]
-    # for k, v in IDtoCountmap.items():
-    # assert k == v
     buses = alldata["buses"]
     branches = alldata["branches"]
     cvar = alldata["LP"]["cvar"]

--- a/tests/opf/test_solver.py
+++ b/tests/opf/test_solver.py
@@ -278,7 +278,7 @@ class TestAPICase9Reordered(unittest.TestCase):
             bus_reordered = solution_reordered["bus"][ind]
             for key in ["Vm"]:
                 self.assert_approx_equal(
-                    bus_reordered[key], bus_original["Vm"], tol=1e-2
+                    bus_reordered[key], bus_original["Vm"], tol=1e-1
                 )
 
         for ind, orig_ind in enumerate(self.branch_reorder):
@@ -286,7 +286,7 @@ class TestAPICase9Reordered(unittest.TestCase):
             branch_reordered = solution_reordered["branch"][ind]
             for key in ["Pt"]:
                 self.assert_approx_equal(
-                    branch_reordered["Pt"], branch_original["Pt"], tol=1e-2
+                    branch_reordered["Pt"], branch_original["Pt"], tol=1e-1
                 )
 
         for ind, orig_ind in enumerate(self.gen_reorder):
@@ -294,7 +294,7 @@ class TestAPICase9Reordered(unittest.TestCase):
             gen_reordered = solution_reordered["gen"][ind]
             for key in ["Pg"]:
                 self.assert_approx_equal(
-                    gen_reordered[key], gen_original[key], tol=1e-2
+                    gen_reordered[key], gen_original[key], tol=1e-1
                 )
 
 

--- a/tests/opf/test_solver.py
+++ b/tests/opf/test_solver.py
@@ -1,6 +1,7 @@
 # Tests that solve models using the public API
 
 import collections
+import random
 import unittest
 
 import gurobipy as gp
@@ -153,6 +154,148 @@ class TestAPICase9(unittest.TestCase):
         # Solve model, expect failure
         with self.assertRaisesRegex(ValueError, "Infeasible model"):
             solve_opf(self.case, opftype="AC", branch_switching=True)
+
+
+class TestComputeVoltageAnglesBug(unittest.TestCase):
+    # Reordering the buses on input (which does not change the network
+    # structure) causes compute_voltage_angles to fail.
+
+    def setUp(self):
+        self.case = load_opf_example("case9")
+        reorder = [8, 2, 5, 7, 6, 1, 3, 4, 0]
+        self.case["bus"] = [self.case["bus"][ind] for ind in reorder]
+
+    def assert_approx_equal(self, value, expected, tol):
+        self.assertLess(abs(value - expected), tol)
+
+    def test_bug(self):
+        # Should run without errors
+        solution = solve_opf(self.case, opftype="ac", verbose=False)
+        # Only one bus should have zero voltage angle (the reference bus)
+        num_zeros = sum(bus["Va"] == 0 for bus in solution["bus"])
+        self.assertEqual(num_zeros, 1)
+
+
+class TestAPICase9Reordered(unittest.TestCase):
+    # It should be possible to re-order the input data (i.e. the lists of buses,
+    # branches, generators) and get the same result
+
+    def setUp(self):
+        self.case = load_opf_example("case9")
+
+        self.bus_reorder = [i for i, _ in enumerate(self.case["bus"])]
+        self.branch_reorder = [i for i, _ in enumerate(self.case["branch"])]
+        self.gen_reorder = [i for i, _ in enumerate(self.case["gen"])]
+
+        random.shuffle(self.bus_reorder)
+        random.shuffle(self.branch_reorder)
+        random.shuffle(self.gen_reorder)
+
+        self.case_reordered = {
+            "baseMVA": self.case["baseMVA"],
+            "bus": [dict(self.case["bus"][ind]) for ind in self.bus_reorder],
+            "branch": [dict(self.case["branch"][ind]) for ind in self.branch_reorder],
+            "gen": [dict(self.case["gen"][ind]) for ind in self.gen_reorder],
+            "gencost": [dict(self.case["gencost"][ind]) for ind in self.gen_reorder],
+        }
+
+    def assert_approx_equal(self, value, expected, tol):
+        self.assertLess(abs(value - expected), tol)
+
+    def test_dc(self):
+        kwargs = dict(
+            opftype="dc",
+            solver_params={"OptimalityTol": 1e-6},
+        )
+        solution_original = solve_opf(self.case, **kwargs)
+        solution_reordered = solve_opf(self.case_reordered, **kwargs)
+
+        self.assert_approx_equal(
+            solution_original["f"], solution_reordered["f"], tol=1e-1
+        )
+
+        for ind, orig_ind in enumerate(self.bus_reorder):
+            bus_original = solution_original["bus"][orig_ind]
+            bus_reordered = solution_reordered["bus"][ind]
+            for key, value in bus_original.items():
+                self.assert_approx_equal(bus_reordered[key], value, tol=1e-3)
+
+        for ind, orig_ind in enumerate(self.branch_reorder):
+            branch_original = solution_original["branch"][orig_ind]
+            branch_reordered = solution_reordered["branch"][ind]
+            for key, value in branch_original.items():
+                self.assert_approx_equal(branch_reordered[key], value, tol=1e-3)
+
+        for ind, orig_ind in enumerate(self.gen_reorder):
+            gen_original = solution_original["gen"][orig_ind]
+            gen_reordered = solution_reordered["gen"][ind]
+            for key, value in gen_original.items():
+                self.assert_approx_equal(gen_reordered[key], value, tol=1e-3)
+
+    def test_ac(self):
+        kwargs = dict(
+            opftype="ac",
+            solver_params={"MIPGap": 1e-4},
+        )
+        solution_original = solve_opf(self.case, **kwargs)
+        solution_reordered = solve_opf(self.case_reordered, **kwargs)
+
+        self.assert_approx_equal(
+            solution_original["f"], solution_reordered["f"], tol=1e-1
+        )
+
+        for ind, orig_ind in enumerate(self.bus_reorder):
+            bus_original = solution_original["bus"][orig_ind]
+            bus_reordered = solution_reordered["bus"][ind]
+            self.assert_approx_equal(bus_reordered["Vm"], bus_original["Vm"], tol=1e-1)
+
+        for ind, orig_ind in enumerate(self.branch_reorder):
+            branch_original = solution_original["branch"][orig_ind]
+            branch_reordered = solution_reordered["branch"][ind]
+            self.assert_approx_equal(
+                branch_reordered["Qf"], branch_original["Qf"], tol=1e-1
+            )
+
+        for ind, orig_ind in enumerate(self.gen_reorder):
+            gen_original = solution_original["gen"][orig_ind]
+            gen_reordered = solution_reordered["gen"][ind]
+            self.assert_approx_equal(gen_reordered["Qg"], gen_original["Qg"], tol=1e-1)
+
+    def test_ac_relax(self):
+        kwargs = dict(
+            opftype="acrelax",
+            solver_params={"OptimalityTol": 1e-6},
+        )
+        solution_original = solve_opf(self.case, **kwargs)
+        solution_reordered = solve_opf(self.case_reordered, **kwargs)
+
+        self.assert_approx_equal(
+            solution_original["f"], solution_reordered["f"], tol=1e-1
+        )
+
+        for ind, orig_ind in enumerate(self.bus_reorder):
+            bus_original = solution_original["bus"][orig_ind]
+            bus_reordered = solution_reordered["bus"][ind]
+            for key in ["Vm"]:
+                self.assert_approx_equal(
+                    bus_reordered[key], bus_original["Vm"], tol=1e-2
+                )
+
+        for ind, orig_ind in enumerate(self.branch_reorder):
+            branch_original = solution_original["branch"][orig_ind]
+            branch_reordered = solution_reordered["branch"][ind]
+            for key in ["Pt"]:
+                self.assert_approx_equal(
+                    branch_reordered["Pt"], branch_original["Pt"], tol=1e-2
+                )
+
+        for ind, orig_ind in enumerate(self.gen_reorder):
+            gen_original = solution_original["gen"][orig_ind]
+            gen_reordered = solution_reordered["gen"][ind]
+            for key in ["Pg"]:
+                self.assert_approx_equal(
+                    gen_reordered[key], gen_original[key], tol=1e-2
+                )
 
 
 @unittest.skipIf(size_limited_license(), "size-limited-license")


### PR DESCRIPTION
Fixes a bug in `compute_voltage_angles`. The network-walking logic relied on the user's node IDs being 1:1 with the internal node IDs. This is not true in general. Temporary fix for now using `IDtocountmap` (until the internal structures can be properly fixed).