### PR TITLE
Changes for scipy 1.11.x 

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "gurobipy-pandas>=1.0.0",
     "numpy",
     "pandas",
-    "scipy>=1.8.0",
+    "scipy>=1.11.0",
 ]
 dynamic = ["version"]
 

--- a/tests/test_bipartite_matching.py
+++ b/tests/test_bipartite_matching.py
@@ -65,7 +65,7 @@ class TestBipartiteMatchingScipySparse(unittest.TestCase):
 
         matching = maximum_bipartite_matching(adjacency, nodes1, nodes2)
 
-        self.assertIsInstance(matching, sp.spmatrix)
+        self.assertIsInstance(matching, sp.sparray)
         self.assertIsNot(matching, adjacency)
         self.assertEqual(matching.shape, (degree, degree))
         self.assert_is_unweighted_matching(matching)
@@ -85,7 +85,7 @@ class TestBipartiteMatchingScipySparse(unittest.TestCase):
 
         matching = maximum_bipartite_matching(adjacency, nodes1, nodes2)
 
-        self.assertIsInstance(matching, sp.spmatrix)
+        self.assertIsInstance(matching, sp.sparray)
         self.assertIsNot(matching, adjacency)
         self.assertEqual(matching.shape, (degree, degree))
         self.assert_is_unweighted_matching(matching)
@@ -103,7 +103,7 @@ class TestBipartiteMatchingScipySparse(unittest.TestCase):
 
         matching = maximum_bipartite_matching(adjacency, nodes1, nodes2)
 
-        self.assertIsInstance(matching, sp.spmatrix)
+        self.assertIsInstance(matching, sp.sparray)
         self.assertIsNot(matching, adjacency)
         self.assertEqual(matching.shape, (6, 6))
         self.assert_is_unweighted_matching(matching)
@@ -121,7 +121,7 @@ class TestBipartiteMatchingScipySparse(unittest.TestCase):
 
         matching = maximum_bipartite_matching(adjacency, nodes1, nodes2)
 
-        self.assertIsInstance(matching, sp.spmatrix)
+        self.assertIsInstance(matching, sp.sparray)
         self.assertIsNot(matching, adjacency)
         self.assertEqual(matching.shape, adjacency.shape)
         self.assert_is_unweighted_matching(matching)
@@ -132,7 +132,7 @@ class TestBipartiteMatchingScipySparse(unittest.TestCase):
 
         matching = maximum_bipartite_matching(sp.csr_matrix(adjacency), nodes1, nodes2)
 
-        self.assertIsInstance(matching, sp.spmatrix)
+        self.assertIsInstance(matching, sp.sparray)
         self.assertIsNot(matching, adjacency)
         self.assertEqual(matching.shape, adjacency.shape)
         self.assert_is_unweighted_matching(matching)
@@ -143,7 +143,7 @@ class TestBipartiteMatchingScipySparse(unittest.TestCase):
 
         matching = maximum_bipartite_matching(sp.csr_array(adjacency), nodes1, nodes2)
 
-        self.assertIsInstance(matching, sp.spmatrix)
+        self.assertIsInstance(matching, sp.sparray)
         self.assertIsNot(matching, adjacency)
         self.assertEqual(matching.shape, adjacency.shape)
         self.assert_is_unweighted_matching(matching)
@@ -154,7 +154,7 @@ class TestBipartiteMatchingScipySparse(unittest.TestCase):
 
         matching = maximum_bipartite_matching(sp.csc_array(adjacency), nodes1, nodes2)
 
-        self.assertIsInstance(matching, sp.spmatrix)
+        self.assertIsInstance(matching, sp.sparray)
         self.assertIsNot(matching, adjacency)
         self.assertEqual(matching.shape, adjacency.shape)
         self.assert_is_unweighted_matching(matching)

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -89,7 +89,7 @@ class TestMinCostFlow(unittest.TestCase):
                 [0.0, 0.0, 0.0, 0.0, 0.0, 2.0],
             ]
         )
-        self.assertIsInstance(sol, sp.spmatrix)
+        self.assertIsInstance(sol, sp.sparray)
         self.assertTrue(check_solution_scipy(sol, [candidate]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")


### PR DESCRIPTION
Related to #121 scipy >=1.11 has changed the behavior from the [release notes](https://docs.scipy.org/doc/scipy/release/1.11.0-notes.html):

> A new public base class [scipy.sparse.sparray](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.sparray.html#scipy.sparse.sparray) was introduced, allowing further extension of the sparse array API (such as the support for 1-dimensional sparse arrays) without breaking backwards compatibility. isinstance(x, scipy.sparse.sparray) to select the new sparse array classes, while isinstance(x, scipy.sparse.spmatrix) selects only the old sparse matrix classes.

This got missed in the actions for #121 (and every commit since) as the Python version used there was 3.8 for which scipy 1.11.x has [no wheel](https://pypi.org/project/scipy/1.11.1/#files)!

@simonbowly This is probably not the correct fix so please take a look.