### PR TITLE
Restrict numpy version to 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "gurobipy[matrixapi]>=10.0.3",
     "gurobipy-pandas>=1.0.0",
-    "numpy",
+    "numpy<2",
     "pandas",
     "scipy>=1.8.0",
 ]


### PR DESCRIPTION
For now, we cannot use numpy 2.0 due to an incompatibility with the current gurobipy releases.