### PR TITLE
Unify approach to size limited skips

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,9 +111,6 @@ def size_limited_license():
             result = True
 
     return result
-
-
-size_limited_license = size_limited_license()
 """
 
 

--- a/tests/opf/test_graphics.py
+++ b/tests/opf/test_graphics.py
@@ -16,21 +16,13 @@ from gurobi_optimods.opf import (
     violation_plot,
 )
 
+from ..utils import size_limited_license
+
 # If plotly is not installed, tests will be skipped
 try:
     import plotly
 except ImportError:
     plotly = None
-
-
-def size_limited_license():
-    with gp.Env(params={"OutputFlag": 0}) as env, gp.Model(env=env) as model:
-        model.addVars(2001)
-        try:
-            model.optimize()
-            return False
-        except gp.GurobiError:
-            return True
 
 
 @unittest.skipIf(plotly is None, "plotly is not installed")

--- a/tests/opf/test_graphics.py
+++ b/tests/opf/test_graphics.py
@@ -6,8 +6,6 @@ import json
 import pathlib
 import unittest
 
-import gurobipy as gp
-
 from gurobi_optimods.datasets import load_opf_example, load_opf_extra
 from gurobi_optimods.opf import (
     compute_violations,

--- a/tests/opf/test_solver.py
+++ b/tests/opf/test_solver.py
@@ -9,15 +9,7 @@ import gurobipy as gp
 from gurobi_optimods.datasets import load_opf_example
 from gurobi_optimods.opf import solve_opf
 
-
-def size_limited_license():
-    with gp.Env(params={"OutputFlag": 0}) as env, gp.Model(env=env) as model:
-        model.addVars(2001)
-        try:
-            model.optimize()
-            return False
-        except gp.GurobiError:
-            return True
+from ..utils import size_limited_license
 
 
 class TestInvalidData(unittest.TestCase):

--- a/tests/opf/test_solver.py
+++ b/tests/opf/test_solver.py
@@ -4,8 +4,6 @@ import collections
 import random
 import unittest
 
-import gurobipy as gp
-
 from gurobi_optimods.datasets import load_opf_example
 from gurobi_optimods.opf import solve_opf
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,3 +27,20 @@ def large_model(test_item):
             raise
 
     return skip_wrapper
+
+
+def size_limited_license():
+    result = False
+
+    try:
+        import gurobipy as gp
+        from gurobipy import GRB
+
+        with gp.Env(params={"OutputFlag": 0}) as env, gp.Model(env=env) as model:
+            x = model.addVars(2001)
+            model.optimize()
+    except gp.GurobiError as e:
+        if e.errno == GRB.Error.SIZE_LIMIT_EXCEEDED:
+            result = True
+
+    return result


### PR DESCRIPTION
- Provide a utility function in unit tests
- Use the same check in doctests and unittests