### PR TITLE
Enable multiple edges in the same direction between two nodes for pandas

### DIFF
--- a/src/gurobi_optimods/datasets.py
+++ b/src/gurobi_optimods/datasets.py
@@ -92,9 +92,7 @@ def load_berlin_metro_graph_data():
 
 
 def _load_simple_graph_pandas(drop_pos=True, capacity=True, cost=True, demand=True):
-    edge_data = pd.read_csv(DATA_FILE_DIR / "graphs/simple_graph_edges.csv").set_index(
-        ["source", "target"]
-    )
+    edge_data = pd.read_csv(DATA_FILE_DIR / "graphs/simple_graph_edges.csv")
     node_data = pd.read_csv(
         DATA_FILE_DIR / "graphs/simple_graph_nodes.csv", index_col=0
     )
@@ -160,7 +158,7 @@ def _convert_pandas_to_scipy(
     the graph structure, the capacity and cost values per edge, and the demand
     values per node.
     """
-    coords = edge_data.index.to_numpy()
+    coords = edge_data[["source", "target"]].to_numpy()
 
     a0 = np.array([c[0] for c in coords])
     a1 = np.array([c[1] for c in coords])

--- a/src/gurobi_optimods/min_cost_flow.py
+++ b/src/gurobi_optimods/min_cost_flow.py
@@ -35,7 +35,7 @@ def min_cost_flow_pandas(
                 {"from": 0, "to": 1, "capacity": 16, "cost": 0}, {"from": 1,
                 "to": 2, "capacity": 10, "cost": 0},
             ]
-        ).set_index(["from", "to"])
+        )
 
         demand_data = pd.DataFrame(
             [{"node": 0, "demand": -1}, {"node": 2, "demand": 1}]

--- a/src/gurobi_optimods/min_cost_flow.py
+++ b/src/gurobi_optimods/min_cost_flow.py
@@ -63,12 +63,12 @@ def min_cost_flow_pandas(
 
         arc_df = arc_data.gppd.add_vars(model, ub="capacity", obj="cost", name="flow")
 
-        source_label, target_label = arc_data.index.names
+        source_label, target_label = ("from", "to")#.index.names
         balance_df = (
             pd.DataFrame(
                 {
-                    "inflow": arc_df["flow"].groupby(target_label).sum(),
-                    "outflow": arc_df["flow"].groupby(source_label).sum(),
+                    "inflow": arc_df[["flow", target_label]].groupby(target_label).sum()["flow"],
+                    "outflow": arc_df[["flow", source_label]].groupby(source_label).sum()["flow"],
                     "demand": demand_data["demand"],
                 }
             )

--- a/src/gurobi_optimods/min_cost_flow.py
+++ b/src/gurobi_optimods/min_cost_flow.py
@@ -67,8 +67,12 @@ def min_cost_flow_pandas(
         balance_df = (
             pd.DataFrame(
                 {
-                    "inflow": arc_df[["flow", target_label]].groupby(target_label).sum()["flow"],
-                    "outflow": arc_df[["flow", source_label]].groupby(source_label).sum()["flow"],
+                    "inflow": arc_df[["flow", target_label]]
+                    .groupby(target_label)
+                    .sum()["flow"],
+                    "outflow": arc_df[["flow", source_label]]
+                    .groupby(source_label)
+                    .sum()["flow"],
                     "demand": demand_data["demand"],
                 }
             )

--- a/src/gurobi_optimods/min_cost_flow.py
+++ b/src/gurobi_optimods/min_cost_flow.py
@@ -63,7 +63,7 @@ def min_cost_flow_pandas(
 
         arc_df = arc_data.gppd.add_vars(model, ub="capacity", obj="cost", name="flow")
 
-        source_label, target_label = ("from", "to")#.index.names
+        source_label, target_label = ("from", "to")
         balance_df = (
             pd.DataFrame(
                 {

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -4,7 +4,10 @@ import numpy as np
 def check_solution_pandas(solution, candidates):
     # Checks whether the solution (`pd.Series`) matches any of the list of
     # candidates (containing `dict`)
-    if any(solution.to_dict() == c for c in candidates):
+    if any(
+        solution.reset_index(drop=True).equals(c.reset_index(drop=True))
+        for c in candidates
+    ):
         return True
     return False
 

--- a/tests/test_max_flow.py
+++ b/tests/test_max_flow.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import pandas as pd
 
 try:
     import networkx as nx
@@ -31,23 +32,25 @@ class TestMaxFlow(unittest.TestCase):
         obj, sol = max_flow(edge_data, 0, 5)
         sol = sol[sol > 0]
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): 1.0,
-            (0, 2): 2.0,
-            (1, 3): 1.0,
-            (2, 3): 1.0,
-            (2, 4): 1.0,
-            (3, 5): 2.0,
-            (4, 5): 1.0,
-        }
-        candidate2 = {
-            (0, 1): 1.0,
-            (0, 2): 2.0,
-            (1, 3): 1.0,
-            (2, 4): 2.0,
-            (3, 5): 1.0,
-            (4, 5): 2.0,
-        }
+
+        candidate = pd.DataFrame(
+            {
+                "source": [np.NaN, np.NaN, 1.0, 2.0, 2.0, 3.0, 4.0],
+                "target": [1, 2, 3, 3, 4, 5, 5],
+                "capacity": [2, 2, 1, 1, 2, 2, 2],
+                "cost": [np.NaN] * 7,
+                "flow": [1.0, 2.0, 1.0, 1.0, 1.0, 2.0, 1.0],
+            }
+        )
+        candidate2 = pd.DataFrame(
+            {
+                "source": [np.NaN, np.NaN, 1.0, 2.0, 3.0, 4.0],
+                "target": [1, 2, 3, 4, 5, 5],
+                "capacity": [2, 2, 1, 2, 2, 2],
+                "cost": [np.NaN] * 6,
+                "flow": [1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+            }
+        )
         self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
 
     def test_empty_pandas(self):
@@ -118,18 +121,16 @@ class TestMaxFlow2(unittest.TestCase):
     def test_pandas(self):
         edge_data, _ = load_graph2_pandas()
         obj, sol = max_flow(edge_data, 0, 4)
-        sol = sol[sol > 0]
+        sol = sol[sol > 0].drop(columns=["cost"])
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): 15.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 1.0,
-            (1, 4): 10.0,
-            (2, 3): 4.0,
-            (2, 4): 5.0,
-            (3, 4): 8.0,
-        }
+        candidate = pd.DataFrame(
+            {
+                "source": [np.NaN, np.NaN, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0],
+                "target": [1, 2, 3, 2, 4, 3, 4, 4],
+                "capacity": [15, 8, 4, 20, 10, 15, 5, 20],
+                "flow": [15.0, 8.0, 4.0, 1.0, 10.0, 4.0, 5.0, 8.0],
+            }
+        )
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
     def test_scipy(self):

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -44,7 +44,7 @@ node_data2 = """
 
 def load_graph2_pandas():
     return (
-        pd.read_csv(io.StringIO(edge_data2)).set_index(["source", "target"]),
+        pd.read_csv(io.StringIO(edge_data2)).rename(columns={"source": "from", "target": "to"}),
         pd.read_csv(io.StringIO(node_data2), index_col=0),
     )
 

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -44,7 +44,9 @@ node_data2 = """
 
 def load_graph2_pandas():
     return (
-        pd.read_csv(io.StringIO(edge_data2)).rename(columns={"source": "from", "target": "to"}),
+        pd.read_csv(io.StringIO(edge_data2)).rename(
+            columns={"source": "from", "target": "to"}
+        ),
         pd.read_csv(io.StringIO(node_data2), index_col=0),
     )
 

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -44,9 +44,7 @@ node_data2 = """
 
 def load_graph2_pandas():
     return (
-        pd.read_csv(io.StringIO(edge_data2)).rename(
-            columns={"source": "from", "target": "to"}
-        ),
+        pd.read_csv(io.StringIO(edge_data2)),
         pd.read_csv(io.StringIO(node_data2), index_col=0),
     )
 
@@ -65,10 +63,19 @@ class TestMinCostFlow(unittest.TestCase):
     def test_pandas(self):
         edge_data, node_data = datasets.simple_graph_pandas()
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
-        sol = sol[sol > 0]
+        sol = sol[sol["flow"] > 0]
         self.assertEqual(cost, 31)
-        candidate = {(0, 1): 1.0, (0, 2): 1.0, (1, 3): 1.0, (2, 4): 2.0, (4, 5): 2.0}
-        self.assertIsInstance(sol, pd.Series)
+        candidate = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 2, 4],
+                "target": [1, 2, 3, 4, 5],
+                "capacity": [2, 2, 1, 2, 2],
+                "cost": [9, 7, 1, 6, 1],
+                "flow": [1.0, 1.0, 1.0, 2.0, 2.0],
+            }
+        )
+
+        self.assertIsInstance(sol, pd.DataFrame)
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
     def test_infeasible(self):
@@ -130,27 +137,28 @@ class TestMinCostFlow2(unittest.TestCase):
     def test_pandas(self):
         edge_data, node_data = load_graph2_pandas()
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
-        sol = sol[sol > 0]
+        sol = sol[sol["flow"] > 0]
         self.assertEqual(cost, 150)
-        candidate = {
-            (0, 1): 12.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 8.0,
-            (2, 3): 15.0,
-            (2, 4): 1.0,
-            (3, 4): 14.0,
-        }
-        candidate2 = {
-            (0, 1): 12.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 8.0,
-            (2, 3): 11.0,
-            (2, 4): 5.0,
-            (3, 4): 10.0,
-        }
-        self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
+        candidate1 = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 1, 2, 2, 3],
+                "target": [1, 2, 3, 2, 3, 4, 4],
+                "capacity": [15, 8, 4, 20, 15, 5, 20],
+                "cost": [4, 4, 2, 2, 1, 3, 2],
+                "flow": [12.0, 8.0, 4.0, 8.0, 15.0, 1.0, 14.0],
+            }
+        )
+        candidate2 = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 1, 2, 2, 3],
+                "target": [1, 2, 3, 2, 3, 4, 4],
+                "capacity": [15, 8, 4, 20, 15, 5, 20],
+                "cost": [4, 4, 2, 2, 1, 3, 2],
+                "flow": [12.0, 8.0, 4.0, 8.0, 11.0, 5.0, 10.0],
+            }
+        )
+
+        self.assertTrue(check_solution_pandas(sol, [candidate1, candidate2]))
 
     def test_scipy(self):
         G, cap, cost, demands = load_graph2_scipy()

--- a/tests/test_min_cut.py
+++ b/tests/test_min_cut.py
@@ -138,7 +138,7 @@ class TestMinCut3(unittest.TestCase):
                 {"source": 3, "target": 6, "capacity": 2.0},
                 {"source": 5, "target": 6, "capacity": 3.0},
             ]
-        ).set_index(["source", "target"])
+        )
 
     def test_pandas(self):
         res = min_cut(self.arc_data, 0, 6)


### PR DESCRIPTION
Enable multiple edges in the same direction between two nodes

### Description
Currently the solver does not support multiple edges of between two nodes in the same direction. This draft PR shows a quick way of enabling this feature in Pandas. This requires changing some minor implementation details about the way that indices are used in the DataFrame when converting.

fixes #155 

 For networkx, it would require a type change to MultiDiGraph, and for scipy, it may not be trivially possible to implement these changes.

This PR draft is mostly intended as a jumping off point for showing it is possible to solve this, rather then a general solution.

### Checklist

- Implementation:
  - [x] Implementation of the Mod in the `gurobi_optimods` installable package
  - [x] Tests for the Mod implementation in `tests/`
  - [x] Docstrings for public API, correctly linked using sphinx-autodoc
- Documentation page:
  - [x] Background and problem specification
  - [x] Example of the input data format (use `gurobi_optimods.datasets` for loading data)
  - [x] Runnable code example
  - [x] Presentation of solutions
  - [x] Included in the mod gallery and toctree
