### PR TITLE
Enable multiple edges in the same direction between two nodes

### DIFF
--- a/src/gurobi_optimods/datasets.py
+++ b/src/gurobi_optimods/datasets.py
@@ -137,14 +137,19 @@ def load_portfolio():
 
 
 def _convert_pandas_to_digraph(
-    edge_data, node_data, capacity=True, cost=True, demand=True
+    edge_data,
+    node_data,
+    capacity=True,
+    cost=True,
+    demand=True,
+    digraph=nx.DiGraph,
 ):
     """
-    Convert from a pandas DataFrame to a networkx.DiGraph with the appropriate
+    Convert from a pandas DataFrame to a networkx.MultiDiGraph with the appropriate
     attributes. For edges: `capacity`, and `cost`. For nodes: `demand`.
     """
     G = nx.from_pandas_edgelist(
-        edge_data.reset_index(), create_using=nx.DiGraph(), edge_attr=True
+        edge_data.reset_index(), create_using=digraph(), edge_attr=True
     )
     if demand:
         for i, d in node_data.iterrows():

--- a/src/gurobi_optimods/datasets.py
+++ b/src/gurobi_optimods/datasets.py
@@ -142,14 +142,16 @@ def _convert_pandas_to_digraph(
     capacity=True,
     cost=True,
     demand=True,
-    digraph=nx.DiGraph,
+    use_multigraph=False,
 ):
     """
     Convert from a pandas DataFrame to a networkx.MultiDiGraph with the appropriate
     attributes. For edges: `capacity`, and `cost`. For nodes: `demand`.
     """
+    graph_type = nx.MultiDiGraph if use_multigraph else nx.DiGraph
+
     G = nx.from_pandas_edgelist(
-        edge_data.reset_index(), create_using=digraph(), edge_attr=True
+        edge_data.reset_index(), create_using=graph_type(), edge_attr=True
     )
     if demand:
         for i, d in node_data.iterrows():

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -3,8 +3,8 @@ import numpy as np
 
 def check_solution_pandas(solution, candidates):
     # Checks whether the solution (`pd.Series`) matches any of the list of
-    # candidates (containing `dict`)
-    if any(solution.to_dict() == c for c in candidates):
+    # candidates (containing `pd.Series`)
+    if any(solution.reset_index().equals(c.reset_index()) for c in candidates):
         return True
     return False
 
@@ -21,7 +21,13 @@ def check_solution_scipy(solution, candidates):
 def check_solution_networkx(solution, candidates):
     # Checks whether the solution (`nx.DiGraph`) matches any of the list of
     # candidates (containing tuples dict `{(i, j): data}`)
-    sol_dict = {(i, j): d for i, j, d in solution.edges(data=True)}
-    if any(sol_dict == c for c in candidates):
-        return True
+    for candidate in candidates:
+
+        def edge_sort(row):
+            return (str(row[0]), str(row[1]))
+
+        if sorted(candidate, key=edge_sort) == sorted(
+            list(solution.edges(data=True)), key=edge_sort
+        ):
+            return True
     return False

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -21,5 +21,6 @@ def check_solution_networkx(solution, candidates):
     # candidates (containing tuples dict `{(i, j): data}`)
     solution_list = sorted(
         [((i, j), data["flow"]) for i, j, data in solution.edges(data=True)],
+        key=str,
     )
-    return any(solution_list == sorted(candidate) for candidate in candidates)
+    return any(solution_list == sorted(candidate, key=str) for candidate in candidates)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,38 +1,25 @@
 import numpy as np
 
 
-def _sort_key(x):
-    return str(x)
-
-
 def check_solution_pandas(solution, candidates):
     # Checks whether the solution (`pd.Series`) matches any of the list of
-    # candidates (containing `dict`)
-    if any(
-        sorted(list(zip(solution.index.to_list(), solution.to_list())), key=_sort_key)
-        == sorted(c, key=_sort_key)
-        for c in candidates
-    ):
-        return True
-    return False
+    # candidates. Each candidate is a list of tuples ((i, j), v) tuples,
+    # compare with the solution in sorted order.
+    solution_list = sorted(solution.items())
+    return any(solution_list == sorted(candidate) for candidate in candidates)
 
 
 def check_solution_scipy(solution, candidates):
     # Checks whether the solution (`sp.sparray`) matches any of the list of
     # candidates (containing `np.ndarray`)
     arr = solution.toarray()
-    if any(np.array_equal(arr, c) for c in candidates):
-        return True
-    return False
+    return any(np.array_equal(arr, c) for c in candidates)
 
 
 def check_solution_networkx(solution, candidates):
     # Checks whether the solution (`nx.DiGraph`) matches any of the list of
     # candidates (containing tuples dict `{(i, j): data}`)
-    sol_list = sorted(
+    solution_list = sorted(
         [((i, j), data["flow"]) for i, j, data in solution.edges(data=True)],
-        key=_sort_key,
     )
-    if any(sol_list == sorted(c, key=_sort_key) for c in candidates):
-        return True
-    return False
+    return any(solution_list == sorted(candidate) for candidate in candidates)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,10 +1,18 @@
 import numpy as np
 
 
+def _sort_key(x):
+    return str(x)
+
+
 def check_solution_pandas(solution, candidates):
     # Checks whether the solution (`pd.Series`) matches any of the list of
     # candidates (containing `dict`)
-    if any(solution.to_dict() == c for c in candidates):
+    if any(
+        sorted(list(zip(solution.index.to_list(), solution.to_list())), key=_sort_key)
+        == sorted(c, key=_sort_key)
+        for c in candidates
+    ):
         return True
     return False
 
@@ -21,30 +29,10 @@ def check_solution_scipy(solution, candidates):
 def check_solution_networkx(solution, candidates):
     # Checks whether the solution (`nx.DiGraph`) matches any of the list of
     # candidates (containing tuples dict `{(i, j): data}`)
-    sol_dict = {(i, j): d for i, j, d in solution.edges(data=True)}
-    if any(sol_dict == c for c in candidates):
+    sol_list = sorted(
+        [((i, j), data["flow"]) for i, j, data in solution.edges(data=True)],
+        key=_sort_key,
+    )
+    if any(sol_list == sorted(c, key=_sort_key) for c in candidates):
         return True
-    return False
-
-
-def check_solution_pandas_multi(solution, candidates):
-    # Checks whether the solution (`pd.Series`) matches any of the list of
-    # candidates (containing `pd.Series`)
-    if any(solution.reset_index().equals(c.reset_index()) for c in candidates):
-        return True
-    return False
-
-
-def check_solution_networkx_multi(solution, candidates):
-    # Checks whether the solution (`nx.DiGraph`) matches any of the list of
-    # candidates (containing tuples dict `{(i, j): data}`)
-    for candidate in candidates:
-
-        def edge_sort(row):
-            return (str(row[0]), str(row[1]))
-
-        if sorted(candidate, key=edge_sort) == sorted(
-            list(solution.edges(data=True)), key=edge_sort
-        ):
-            return True
     return False

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -3,8 +3,8 @@ import numpy as np
 
 def check_solution_pandas(solution, candidates):
     # Checks whether the solution (`pd.Series`) matches any of the list of
-    # candidates (containing `pd.Series`)
-    if any(solution.reset_index().equals(c.reset_index()) for c in candidates):
+    # candidates (containing `dict`)
+    if any(solution.to_dict() == c for c in candidates):
         return True
     return False
 
@@ -19,6 +19,23 @@ def check_solution_scipy(solution, candidates):
 
 
 def check_solution_networkx(solution, candidates):
+    # Checks whether the solution (`nx.DiGraph`) matches any of the list of
+    # candidates (containing tuples dict `{(i, j): data}`)
+    sol_dict = {(i, j): d for i, j, d in solution.edges(data=True)}
+    if any(sol_dict == c for c in candidates):
+        return True
+    return False
+
+
+def check_solution_pandas_multi(solution, candidates):
+    # Checks whether the solution (`pd.Series`) matches any of the list of
+    # candidates (containing `pd.Series`)
+    if any(solution.reset_index().equals(c.reset_index()) for c in candidates):
+        return True
+    return False
+
+
+def check_solution_networkx_multi(solution, candidates):
     # Checks whether the solution (`nx.DiGraph`) matches any of the list of
     # candidates (containing tuples dict `{(i, j): data}`)
     for candidate in candidates:

--- a/tests/test_max_flow.py
+++ b/tests/test_max_flow.py
@@ -31,23 +31,23 @@ class TestMaxFlow(unittest.TestCase):
         obj, sol = max_flow(edge_data, 0, 5)
         sol = sol[sol > 0]
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): 1.0,
-            (0, 2): 2.0,
-            (1, 3): 1.0,
-            (2, 3): 1.0,
-            (2, 4): 1.0,
-            (3, 5): 2.0,
-            (4, 5): 1.0,
-        }
-        candidate2 = {
-            (0, 1): 1.0,
-            (0, 2): 2.0,
-            (1, 3): 1.0,
-            (2, 4): 2.0,
-            (3, 5): 1.0,
-            (4, 5): 2.0,
-        }
+        candidate = [
+            ((0, 1), 1.0),
+            ((0, 2), 2.0),
+            ((1, 3), 1.0),
+            ((2, 3), 1.0),
+            ((2, 4), 1.0),
+            ((3, 5), 2.0),
+            ((4, 5), 1.0),
+        ]
+        candidate2 = [
+            ((0, 1), 1.0),
+            ((0, 2), 2.0),
+            ((1, 3), 1.0),
+            ((2, 4), 2.0),
+            ((3, 5), 1.0),
+            ((4, 5), 2.0),
+        ]
         self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
 
     def test_empty_pandas(self):
@@ -84,23 +84,23 @@ class TestMaxFlow(unittest.TestCase):
         G = datasets.simple_graph_networkx()
         obj, sol = max_flow(G, 0, 5)
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): {"flow": 1},
-            (0, 2): {"flow": 2},
-            (1, 3): {"flow": 1},
-            (2, 4): {"flow": 2},
-            (3, 5): {"flow": 1},
-            (4, 5): {"flow": 2},
-        }
-        candidate2 = {
-            (0, 1): {"flow": 1.0},
-            (0, 2): {"flow": 2.0},
-            (1, 3): {"flow": 1.0},
-            (2, 3): {"flow": 1.0},
-            (2, 4): {"flow": 1.0},
-            (3, 5): {"flow": 2.0},
-            (4, 5): {"flow": 1.0},
-        }
+        candidate = [
+            ((0, 1), 1),
+            ((0, 2), 2),
+            ((1, 3), 1),
+            ((2, 4), 2),
+            ((3, 5), 1),
+            ((4, 5), 2),
+        ]
+        candidate2 = [
+            ((0, 1), 1.0),
+            ((0, 2), 2.0),
+            ((1, 3), 1.0),
+            ((2, 3), 1.0),
+            ((2, 4), 1.0),
+            ((3, 5), 2.0),
+            ((4, 5), 1.0),
+        ]
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
@@ -120,16 +120,16 @@ class TestMaxFlow2(unittest.TestCase):
         obj, sol = max_flow(edge_data, 0, 4)
         sol = sol[sol > 0]
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): 15.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 1.0,
-            (1, 4): 10.0,
-            (2, 3): 4.0,
-            (2, 4): 5.0,
-            (3, 4): 8.0,
-        }
+        candidate = [
+            ((0, 1), 15.0),
+            ((0, 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 1.0),
+            ((1, 4), 10.0),
+            ((2, 3), 4.0),
+            ((2, 4), 5.0),
+            ((3, 4), 8.0),
+        ]
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
     def test_scipy(self):
@@ -152,23 +152,23 @@ class TestMaxFlow2(unittest.TestCase):
         G = load_graph2_networkx()
         obj, sol = max_flow(G, 0, 4)
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): {"flow": 15.0},
-            (0, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (1, 2): {"flow": 1.0},
-            (1, 4): {"flow": 10.0},
-            (2, 3): {"flow": 4.0},
-            (2, 4): {"flow": 5.0},
-            (3, 4): {"flow": 8.0},
-        }
-        candidate2 = {
-            (0, 1): {"flow": 15},
-            (0, 2): {"flow": 8},
-            (1, 2): {"flow": 1},
-            (1, 3): {"flow": 4},
-            (1, 4): {"flow": 10},
-            (2, 3): {"flow": 9},
-            (3, 4): {"flow": 13},
-        }
+        candidate = [
+            ((0, 1), 15.0),
+            ((0, 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 1.0),
+            ((1, 4), 10.0),
+            ((2, 3), 4.0),
+            ((2, 4), 5.0),
+            ((3, 4), 8.0),
+        ]
+        candidate2 = [
+            ((0, 1), 15),
+            ((0, 2), 8),
+            ((1, 2), 1),
+            ((1, 3), 4),
+            ((1, 4), 10),
+            ((2, 3), 9),
+            ((3, 4), 13),
+        ]
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))

--- a/tests/test_max_flow.py
+++ b/tests/test_max_flow.py
@@ -7,8 +7,6 @@ try:
 except ImportError:
     nx = None
 
-import pandas as pd
-
 import gurobi_optimods.datasets as datasets
 from gurobi_optimods.max_flow import max_flow
 

--- a/tests/test_max_flow.py
+++ b/tests/test_max_flow.py
@@ -33,20 +33,23 @@ class TestMaxFlow(unittest.TestCase):
         obj, sol = max_flow(edge_data, 0, 5)
         sol = sol[sol > 0]
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = pd.DataFrame(
-            {
-                "source": [0, 0, 1, 2, 2, 3, 4],
-                "target": [1, 2, 3, 3, 4, 5, 5],
-                "flow": [1.0, 2.0, 1.0, 1.0, 1.0, 2.0, 1.0],
-            }
-        ).set_index(["source", "target"])
-        candidate2 = pd.DataFrame(
-            {
-                "source": [0, 0, 1, 2, 3, 4],
-                "target": [1, 2, 3, 4, 5, 5],
-                "flow": [1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
-            }
-        ).set_index(["source", "target"])
+        candidate = {
+            (0, 1): 1.0,
+            (0, 2): 2.0,
+            (1, 3): 1.0,
+            (2, 3): 1.0,
+            (2, 4): 1.0,
+            (3, 5): 2.0,
+            (4, 5): 1.0,
+        }
+        candidate2 = {
+            (0, 1): 1.0,
+            (0, 2): 2.0,
+            (1, 3): 1.0,
+            (2, 4): 2.0,
+            (3, 5): 1.0,
+            (4, 5): 2.0,
+        }
         self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
 
     def test_empty_pandas(self):
@@ -83,23 +86,23 @@ class TestMaxFlow(unittest.TestCase):
         G = datasets.simple_graph_networkx()
         obj, sol = max_flow(G, 0, 5)
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = [
-            (0, 1, {"flow": 1}),
-            (0, 2, {"flow": 2}),
-            (1, 3, {"flow": 1}),
-            (2, 4, {"flow": 2}),
-            (3, 5, {"flow": 1}),
-            (4, 5, {"flow": 2}),
-        ]
-        candidate2 = [
-            (0, 1, {"flow": 1.0}),
-            (0, 2, {"flow": 2.0}),
-            (1, 3, {"flow": 1.0}),
-            (2, 3, {"flow": 1.0}),
-            (2, 4, {"flow": 1.0}),
-            (3, 5, {"flow": 2.0}),
-            (4, 5, {"flow": 1.0}),
-        ]
+        candidate = {
+            (0, 1): {"flow": 1},
+            (0, 2): {"flow": 2},
+            (1, 3): {"flow": 1},
+            (2, 4): {"flow": 2},
+            (3, 5): {"flow": 1},
+            (4, 5): {"flow": 2},
+        }
+        candidate2 = {
+            (0, 1): {"flow": 1.0},
+            (0, 2): {"flow": 2.0},
+            (1, 3): {"flow": 1.0},
+            (2, 3): {"flow": 1.0},
+            (2, 4): {"flow": 1.0},
+            (3, 5): {"flow": 2.0},
+            (4, 5): {"flow": 1.0},
+        }
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
@@ -119,13 +122,16 @@ class TestMaxFlow2(unittest.TestCase):
         obj, sol = max_flow(edge_data, 0, 4)
         sol = sol[sol > 0]
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = pd.DataFrame(
-            {
-                "source": [0, 0, 1, 1, 1, 2, 2, 3],
-                "target": [1, 2, 3, 2, 4, 3, 4, 4],
-                "flow": [15.0, 8.0, 4.0, 1.0, 10.0, 4.0, 5.0, 8.0],
-            }
-        ).set_index(["source", "target"])
+        candidate = {
+            (0, 1): 15.0,
+            (0, 2): 8.0,
+            (1, 3): 4.0,
+            (1, 2): 1.0,
+            (1, 4): 10.0,
+            (2, 3): 4.0,
+            (2, 4): 5.0,
+            (3, 4): 8.0,
+        }
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
     def test_scipy(self):
@@ -148,23 +154,23 @@ class TestMaxFlow2(unittest.TestCase):
         G = load_graph2_networkx()
         obj, sol = max_flow(G, 0, 4)
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = [
-            (0, 1, {"flow": 15.0}),
-            (0, 2, {"flow": 8.0}),
-            (1, 3, {"flow": 4.0}),
-            (1, 2, {"flow": 1.0}),
-            (1, 4, {"flow": 10.0}),
-            (2, 3, {"flow": 4.0}),
-            (2, 4, {"flow": 5.0}),
-            (3, 4, {"flow": 8.0}),
-        ]
-        candidate2 = [
-            (0, 1, {"flow": 15}),
-            (0, 2, {"flow": 8}),
-            (1, 2, {"flow": 1}),
-            (1, 3, {"flow": 4}),
-            (1, 4, {"flow": 10}),
-            (2, 3, {"flow": 9}),
-            (3, 4, {"flow": 13}),
-        ]
+        candidate = {
+            (0, 1): {"flow": 15.0},
+            (0, 2): {"flow": 8.0},
+            (1, 3): {"flow": 4.0},
+            (1, 2): {"flow": 1.0},
+            (1, 4): {"flow": 10.0},
+            (2, 3): {"flow": 4.0},
+            (2, 4): {"flow": 5.0},
+            (3, 4): {"flow": 8.0},
+        }
+        candidate2 = {
+            (0, 1): {"flow": 15},
+            (0, 2): {"flow": 8},
+            (1, 2): {"flow": 1},
+            (1, 3): {"flow": 4},
+            (1, 4): {"flow": 10},
+            (2, 3): {"flow": 9},
+            (3, 4): {"flow": 13},
+        }
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))

--- a/tests/test_max_flow.py
+++ b/tests/test_max_flow.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     nx = None
 
+import pandas as pd
+
 import gurobi_optimods.datasets as datasets
 from gurobi_optimods.max_flow import max_flow
 
@@ -31,23 +33,20 @@ class TestMaxFlow(unittest.TestCase):
         obj, sol = max_flow(edge_data, 0, 5)
         sol = sol[sol > 0]
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): 1.0,
-            (0, 2): 2.0,
-            (1, 3): 1.0,
-            (2, 3): 1.0,
-            (2, 4): 1.0,
-            (3, 5): 2.0,
-            (4, 5): 1.0,
-        }
-        candidate2 = {
-            (0, 1): 1.0,
-            (0, 2): 2.0,
-            (1, 3): 1.0,
-            (2, 4): 2.0,
-            (3, 5): 1.0,
-            (4, 5): 2.0,
-        }
+        candidate = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 2, 2, 3, 4],
+                "target": [1, 2, 3, 3, 4, 5, 5],
+                "flow": [1.0, 2.0, 1.0, 1.0, 1.0, 2.0, 1.0],
+            }
+        ).set_index(["source", "target"])
+        candidate2 = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 2, 3, 4],
+                "target": [1, 2, 3, 4, 5, 5],
+                "flow": [1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+            }
+        ).set_index(["source", "target"])
         self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
 
     def test_empty_pandas(self):
@@ -84,23 +83,23 @@ class TestMaxFlow(unittest.TestCase):
         G = datasets.simple_graph_networkx()
         obj, sol = max_flow(G, 0, 5)
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): {"flow": 1},
-            (0, 2): {"flow": 2},
-            (1, 3): {"flow": 1},
-            (2, 4): {"flow": 2},
-            (3, 5): {"flow": 1},
-            (4, 5): {"flow": 2},
-        }
-        candidate2 = {
-            (0, 1): {"flow": 1.0},
-            (0, 2): {"flow": 2.0},
-            (1, 3): {"flow": 1.0},
-            (2, 3): {"flow": 1.0},
-            (2, 4): {"flow": 1.0},
-            (3, 5): {"flow": 2.0},
-            (4, 5): {"flow": 1.0},
-        }
+        candidate = [
+            (0, 1, {"flow": 1}),
+            (0, 2, {"flow": 2}),
+            (1, 3, {"flow": 1}),
+            (2, 4, {"flow": 2}),
+            (3, 5, {"flow": 1}),
+            (4, 5, {"flow": 2}),
+        ]
+        candidate2 = [
+            (0, 1, {"flow": 1.0}),
+            (0, 2, {"flow": 2.0}),
+            (1, 3, {"flow": 1.0}),
+            (2, 3, {"flow": 1.0}),
+            (2, 4, {"flow": 1.0}),
+            (3, 5, {"flow": 2.0}),
+            (4, 5, {"flow": 1.0}),
+        ]
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
@@ -120,16 +119,13 @@ class TestMaxFlow2(unittest.TestCase):
         obj, sol = max_flow(edge_data, 0, 4)
         sol = sol[sol > 0]
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): 15.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 1.0,
-            (1, 4): 10.0,
-            (2, 3): 4.0,
-            (2, 4): 5.0,
-            (3, 4): 8.0,
-        }
+        candidate = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 1, 1, 2, 2, 3],
+                "target": [1, 2, 3, 2, 4, 3, 4, 4],
+                "flow": [15.0, 8.0, 4.0, 1.0, 10.0, 4.0, 5.0, 8.0],
+            }
+        ).set_index(["source", "target"])
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
     def test_scipy(self):
@@ -152,23 +148,23 @@ class TestMaxFlow2(unittest.TestCase):
         G = load_graph2_networkx()
         obj, sol = max_flow(G, 0, 4)
         self.assertEqual(obj, self.expected_max_flow)
-        candidate = {
-            (0, 1): {"flow": 15.0},
-            (0, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (1, 2): {"flow": 1.0},
-            (1, 4): {"flow": 10.0},
-            (2, 3): {"flow": 4.0},
-            (2, 4): {"flow": 5.0},
-            (3, 4): {"flow": 8.0},
-        }
-        candidate2 = {
-            (0, 1): {"flow": 15},
-            (0, 2): {"flow": 8},
-            (1, 2): {"flow": 1},
-            (1, 3): {"flow": 4},
-            (1, 4): {"flow": 10},
-            (2, 3): {"flow": 9},
-            (3, 4): {"flow": 13},
-        }
+        candidate = [
+            (0, 1, {"flow": 15.0}),
+            (0, 2, {"flow": 8.0}),
+            (1, 3, {"flow": 4.0}),
+            (1, 2, {"flow": 1.0}),
+            (1, 4, {"flow": 10.0}),
+            (2, 3, {"flow": 4.0}),
+            (2, 4, {"flow": 5.0}),
+            (3, 4, {"flow": 8.0}),
+        ]
+        candidate2 = [
+            (0, 1, {"flow": 15}),
+            (0, 2, {"flow": 8}),
+            (1, 2, {"flow": 1}),
+            (1, 3, {"flow": 4}),
+            (1, 4, {"flow": 10}),
+            (2, 3, {"flow": 9}),
+            (3, 4, {"flow": 13}),
+        ]
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -41,6 +41,20 @@ node_data2 = """
 4,15
 """
 
+edge_data3 = """
+source,target,capacity,cost
+0,1,15,4
+0,2,8,4
+1,3,4,2
+1,2,20,2
+1,4,10,6
+2,3,15,1
+2,4,5,3
+3,4,20,2
+2,3,1,-100
+2,3,1,10
+"""
+
 
 def load_graph2_pandas():
     return (
@@ -49,14 +63,26 @@ def load_graph2_pandas():
     )
 
 
-def load_graph2_networkx():
+def load_graph2_networkx(digraph=nx.DiGraph):
     edge_data, node_data = load_graph2_pandas()
-    return datasets._convert_pandas_to_digraph(edge_data, node_data)
+    return datasets._convert_pandas_to_digraph(edge_data, node_data, digraph=digraph)
 
 
 def load_graph2_scipy():
     edge_data, node_data = load_graph2_pandas()
     return datasets._convert_pandas_to_scipy(edge_data, node_data)
+
+
+def load_graph3_pandas():
+    return (
+        pd.read_csv(io.StringIO(edge_data3)).set_index(["source", "target"]),
+        pd.read_csv(io.StringIO(node_data2), index_col=0),
+    )
+
+
+def load_graph3_networkx(digraph=nx.DiGraph):
+    edge_data, node_data = load_graph3_pandas()
+    return datasets._convert_pandas_to_digraph(edge_data, node_data, digraph=digraph)
 
 
 class TestMinCostFlow(unittest.TestCase):
@@ -65,7 +91,13 @@ class TestMinCostFlow(unittest.TestCase):
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
         sol = sol[sol > 0]
         self.assertEqual(cost, 31)
-        candidate = {(0, 1): 1.0, (0, 2): 1.0, (1, 3): 1.0, (2, 4): 2.0, (4, 5): 2.0}
+        candidate = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 2, 4],
+                "target": [1, 2, 3, 4, 5],
+                "flow": [1.0, 1.0, 1.0, 2.0, 2.0],
+            }
+        ).set_index(["source", "target"])
         self.assertIsInstance(sol, pd.Series)
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
@@ -97,13 +129,13 @@ class TestMinCostFlow(unittest.TestCase):
         G = datasets.simple_graph_networkx()
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 31)
-        expected = {
-            (0, 1): {"flow": 1.0},
-            (0, 2): {"flow": 1.0},
-            (1, 3): {"flow": 1.0},
-            (2, 4): {"flow": 2.0},
-            (4, 5): {"flow": 2.0},
-        }
+        expected = [
+            (0, 1, {"flow": 1.0}),
+            (0, 2, {"flow": 1.0}),
+            (1, 3, {"flow": 1.0}),
+            (2, 4, {"flow": 2.0}),
+            (4, 5, {"flow": 2.0}),
+        ]
         self.assertIsInstance(sol, nx.Graph)
         self.assertTrue(check_solution_networkx(sol, [expected]))
 
@@ -113,13 +145,13 @@ class TestMinCostFlow(unittest.TestCase):
         G = nx.relabel_nodes(G, {0: "s", 5: "t"})
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 31)
-        expected = {
-            ("s", 1): {"flow": 1.0},
-            ("s", 2): {"flow": 1.0},
-            (1, 3): {"flow": 1.0},
-            (2, 4): {"flow": 2.0},
-            (4, "t"): {"flow": 2.0},
-        }
+        expected = [
+            ("s", 1, {"flow": 1.0}),
+            ("s", 2, {"flow": 1.0}),
+            (1, 3, {"flow": 1.0}),
+            (2, 4, {"flow": 2.0}),
+            (4, "t", {"flow": 2.0}),
+        ]
         self.assertIsInstance(sol, nx.Graph)
         self.assertTrue(check_solution_networkx(sol, [expected]))
 
@@ -130,24 +162,20 @@ class TestMinCostFlow2(unittest.TestCase):
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
         sol = sol[sol > 0]
         self.assertEqual(cost, 150)
-        candidate = {
-            (0, 1): 12.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 8.0,
-            (2, 3): 15.0,
-            (2, 4): 1.0,
-            (3, 4): 14.0,
-        }
-        candidate2 = {
-            (0, 1): 12.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 8.0,
-            (2, 3): 11.0,
-            (2, 4): 5.0,
-            (3, 4): 10.0,
-        }
+        candidate = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 1, 2, 2, 3],
+                "target": [1, 2, 3, 2, 3, 4, 4],
+                "flow": [12.0, 8.0, 4.0, 8.0, 15.0, 1.0, 14.0],
+            }
+        ).set_index(["source", "target"])
+        candidate2 = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 1, 2, 2, 3],
+                "target": [1, 2, 3, 2, 3, 4, 4],
+                "flow": [12.0, 8.0, 4.0, 8.0, 11.0, 5.0, 10.0],
+            }
+        ).set_index(["source", "target"])
         self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
 
     def test_scipy(self):
@@ -169,48 +197,84 @@ class TestMinCostFlow2(unittest.TestCase):
         G = load_graph2_networkx()
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 150)
-        candidate = {
-            (0, 1): {"flow": 12.0},
-            (0, 2): {"flow": 8.0},
-            (1, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (2, 3): {"flow": 11.0},
-            (2, 4): {"flow": 5.0},
-            (3, 4): {"flow": 10.0},
-        }
-        candidate2 = {
-            (0, 1): {"flow": 12.0},
-            (0, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (1, 2): {"flow": 8.0},
-            (2, 3): {"flow": 15.0},
-            (2, 4): {"flow": 1.0},
-            (3, 4): {"flow": 14.0},
-        }
+        candidate = [
+            (0, 1, {"flow": 12.0}),
+            (0, 2, {"flow": 8.0}),
+            (1, 2, {"flow": 8.0}),
+            (1, 3, {"flow": 4.0}),
+            (2, 3, {"flow": 11.0}),
+            (2, 4, {"flow": 5.0}),
+            (3, 4, {"flow": 10.0}),
+        ]
+        candidate2 = [
+            (0, 1, {"flow": 12.0}),
+            (0, 2, {"flow": 8.0}),
+            (1, 3, {"flow": 4.0}),
+            (1, 2, {"flow": 8.0}),
+            (2, 3, {"flow": 15.0}),
+            (2, 4, {"flow": 1.0}),
+            (3, 4, {"flow": 14.0}),
+        ]
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
     def test_networkx_renamed(self):
-        G = load_graph2_networkx()
+        G = load_graph2_networkx(digraph=nx.MultiDiGraph)
         G = nx.relabel_nodes(G, {0: "s", 4: "t"})
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 150)
-        candidate = {
-            ("s", 1): {"flow": 12.0},
-            ("s", 2): {"flow": 8.0},
-            (1, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (2, 3): {"flow": 11.0},
-            (2, "t"): {"flow": 5.0},
-            (3, "t"): {"flow": 10.0},
-        }
-        candidate2 = {
-            ("s", 1): {"flow": 12.0},
-            ("s", 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (1, 2): {"flow": 8.0},
-            (2, 3): {"flow": 15.0},
-            (2, "t"): {"flow": 1.0},
-            (3, "t"): {"flow": 14.0},
-        }
+        candidate = [
+            ("s", 1, {"flow": 12.0}),
+            ("s", 2, {"flow": 8.0}),
+            (1, 2, {"flow": 8.0}),
+            (1, 3, {"flow": 4.0}),
+            (2, 3, {"flow": 11.0}),
+            (2, "t", {"flow": 5.0}),
+            (3, "t", {"flow": 10.0}),
+        ]
+        candidate2 = [
+            ("s", 1, {"flow": 12.0}),
+            ("s", 2, {"flow": 8.0}),
+            (1, 3, {"flow": 4.0}),
+            (1, 2, {"flow": 8.0}),
+            (2, 3, {"flow": 15.0}),
+            (2, "t", {"flow": 1.0}),
+            (3, "t", {"flow": 14.0}),
+        ]
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
+
+
+class TestMinCostFlow3(unittest.TestCase):
+    def test_pandas(self):
+        edge_data, node_data = load_graph3_pandas()
+        cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
+        sol = sol[sol > 0]
+        self.assertEqual(cost, 49.0)
+
+        candidate = pd.DataFrame(
+            {
+                "source": [0, 0, 1, 1, 2, 2, 3, 2],
+                "target": [1, 2, 3, 2, 3, 4, 4, 3],
+                "flow": [12.0, 8.0, 4.0, 8.0, 10.0, 5.0, 10.0, 1.0],
+            }
+        ).set_index(["source", "target"])
+
+        self.assertTrue(check_solution_pandas(sol, [candidate]))
+
+    @unittest.skipIf(nx is None, "networkx is not installed")
+    def test_networkx(self):
+        G = load_graph3_networkx(digraph=nx.MultiDiGraph)
+        cost, sol = mcf.min_cost_flow_networkx(G)
+        self.assertEqual(cost, 49.0)
+        candidate = [
+            (0, 1, {"flow": 12.0}),
+            (0, 2, {"flow": 8.0}),
+            (1, 3, {"flow": 4.0}),
+            (1, 2, {"flow": 8.0}),
+            (2, 3, {"flow": 10.0}),
+            (2, 3, {"flow": 1.0}),
+            (2, 4, {"flow": 5.0}),
+            (3, 4, {"flow": 10.0}),
+        ]
+
+        self.assertTrue(check_solution_networkx(sol, [candidate]))

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -63,9 +63,9 @@ def load_graph2_pandas():
     )
 
 
-def load_graph2_networkx(digraph=nx.DiGraph):
+def load_graph2_networkx():
     edge_data, node_data = load_graph2_pandas()
-    return datasets._convert_pandas_to_digraph(edge_data, node_data, digraph=digraph)
+    return datasets._convert_pandas_to_digraph(edge_data, node_data)
 
 
 def load_graph2_scipy():
@@ -80,9 +80,11 @@ def load_graph3_pandas():
     )
 
 
-def load_graph3_networkx(digraph=nx.DiGraph):
+def load_graph3_networkx(use_multigraph):
     edge_data, node_data = load_graph3_pandas()
-    return datasets._convert_pandas_to_digraph(edge_data, node_data, digraph=digraph)
+    return datasets._convert_pandas_to_digraph(
+        edge_data, node_data, use_multigraph=use_multigraph
+    )
 
 
 class TestMinCostFlow(unittest.TestCase):
@@ -269,7 +271,7 @@ class TestMinCostFlow3(unittest.TestCase):
 
     @unittest.skipIf(nx is None, "networkx is not installed")
     def test_networkx(self):
-        G = load_graph3_networkx(digraph=nx.MultiDiGraph)
+        G = load_graph3_networkx(use_multigraph=True)
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 49.0)
         candidate = [

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -15,7 +15,9 @@ import gurobi_optimods.min_cost_flow as mcf
 
 from .test_graph_utils import (
     check_solution_networkx,
+    check_solution_networkx_multi,
     check_solution_pandas,
+    check_solution_pandas_multi,
     check_solution_scipy,
 )
 
@@ -91,13 +93,7 @@ class TestMinCostFlow(unittest.TestCase):
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
         sol = sol[sol > 0]
         self.assertEqual(cost, 31)
-        candidate = pd.DataFrame(
-            {
-                "source": [0, 0, 1, 2, 4],
-                "target": [1, 2, 3, 4, 5],
-                "flow": [1.0, 1.0, 1.0, 2.0, 2.0],
-            }
-        ).set_index(["source", "target"])
+        candidate = {(0, 1): 1.0, (0, 2): 1.0, (1, 3): 1.0, (2, 4): 2.0, (4, 5): 2.0}
         self.assertIsInstance(sol, pd.Series)
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
@@ -129,13 +125,13 @@ class TestMinCostFlow(unittest.TestCase):
         G = datasets.simple_graph_networkx()
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 31)
-        expected = [
-            (0, 1, {"flow": 1.0}),
-            (0, 2, {"flow": 1.0}),
-            (1, 3, {"flow": 1.0}),
-            (2, 4, {"flow": 2.0}),
-            (4, 5, {"flow": 2.0}),
-        ]
+        expected = {
+            (0, 1): {"flow": 1.0},
+            (0, 2): {"flow": 1.0},
+            (1, 3): {"flow": 1.0},
+            (2, 4): {"flow": 2.0},
+            (4, 5): {"flow": 2.0},
+        }
         self.assertIsInstance(sol, nx.Graph)
         self.assertTrue(check_solution_networkx(sol, [expected]))
 
@@ -145,13 +141,13 @@ class TestMinCostFlow(unittest.TestCase):
         G = nx.relabel_nodes(G, {0: "s", 5: "t"})
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 31)
-        expected = [
-            ("s", 1, {"flow": 1.0}),
-            ("s", 2, {"flow": 1.0}),
-            (1, 3, {"flow": 1.0}),
-            (2, 4, {"flow": 2.0}),
-            (4, "t", {"flow": 2.0}),
-        ]
+        expected = {
+            ("s", 1): {"flow": 1.0},
+            ("s", 2): {"flow": 1.0},
+            (1, 3): {"flow": 1.0},
+            (2, 4): {"flow": 2.0},
+            (4, "t"): {"flow": 2.0},
+        }
         self.assertIsInstance(sol, nx.Graph)
         self.assertTrue(check_solution_networkx(sol, [expected]))
 
@@ -162,20 +158,24 @@ class TestMinCostFlow2(unittest.TestCase):
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
         sol = sol[sol > 0]
         self.assertEqual(cost, 150)
-        candidate = pd.DataFrame(
-            {
-                "source": [0, 0, 1, 1, 2, 2, 3],
-                "target": [1, 2, 3, 2, 3, 4, 4],
-                "flow": [12.0, 8.0, 4.0, 8.0, 15.0, 1.0, 14.0],
-            }
-        ).set_index(["source", "target"])
-        candidate2 = pd.DataFrame(
-            {
-                "source": [0, 0, 1, 1, 2, 2, 3],
-                "target": [1, 2, 3, 2, 3, 4, 4],
-                "flow": [12.0, 8.0, 4.0, 8.0, 11.0, 5.0, 10.0],
-            }
-        ).set_index(["source", "target"])
+        candidate = {
+            (0, 1): 12.0,
+            (0, 2): 8.0,
+            (1, 3): 4.0,
+            (1, 2): 8.0,
+            (2, 3): 15.0,
+            (2, 4): 1.0,
+            (3, 4): 14.0,
+        }
+        candidate2 = {
+            (0, 1): 12.0,
+            (0, 2): 8.0,
+            (1, 3): 4.0,
+            (1, 2): 8.0,
+            (2, 3): 11.0,
+            (2, 4): 5.0,
+            (3, 4): 10.0,
+        }
         self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
 
     def test_scipy(self):
@@ -197,50 +197,50 @@ class TestMinCostFlow2(unittest.TestCase):
         G = load_graph2_networkx()
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 150)
-        candidate = [
-            (0, 1, {"flow": 12.0}),
-            (0, 2, {"flow": 8.0}),
-            (1, 2, {"flow": 8.0}),
-            (1, 3, {"flow": 4.0}),
-            (2, 3, {"flow": 11.0}),
-            (2, 4, {"flow": 5.0}),
-            (3, 4, {"flow": 10.0}),
-        ]
-        candidate2 = [
-            (0, 1, {"flow": 12.0}),
-            (0, 2, {"flow": 8.0}),
-            (1, 3, {"flow": 4.0}),
-            (1, 2, {"flow": 8.0}),
-            (2, 3, {"flow": 15.0}),
-            (2, 4, {"flow": 1.0}),
-            (3, 4, {"flow": 14.0}),
-        ]
+        candidate = {
+            (0, 1): {"flow": 12.0},
+            (0, 2): {"flow": 8.0},
+            (1, 2): {"flow": 8.0},
+            (1, 3): {"flow": 4.0},
+            (2, 3): {"flow": 11.0},
+            (2, 4): {"flow": 5.0},
+            (3, 4): {"flow": 10.0},
+        }
+        candidate2 = {
+            (0, 1): {"flow": 12.0},
+            (0, 2): {"flow": 8.0},
+            (1, 3): {"flow": 4.0},
+            (1, 2): {"flow": 8.0},
+            (2, 3): {"flow": 15.0},
+            (2, 4): {"flow": 1.0},
+            (3, 4): {"flow": 14.0},
+        }
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
     def test_networkx_renamed(self):
-        G = load_graph2_networkx(digraph=nx.MultiDiGraph)
+        G = load_graph2_networkx()
         G = nx.relabel_nodes(G, {0: "s", 4: "t"})
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 150)
-        candidate = [
-            ("s", 1, {"flow": 12.0}),
-            ("s", 2, {"flow": 8.0}),
-            (1, 2, {"flow": 8.0}),
-            (1, 3, {"flow": 4.0}),
-            (2, 3, {"flow": 11.0}),
-            (2, "t", {"flow": 5.0}),
-            (3, "t", {"flow": 10.0}),
-        ]
-        candidate2 = [
-            ("s", 1, {"flow": 12.0}),
-            ("s", 2, {"flow": 8.0}),
-            (1, 3, {"flow": 4.0}),
-            (1, 2, {"flow": 8.0}),
-            (2, 3, {"flow": 15.0}),
-            (2, "t", {"flow": 1.0}),
-            (3, "t", {"flow": 14.0}),
-        ]
+        candidate = {
+            ("s", 1): {"flow": 12.0},
+            ("s", 2): {"flow": 8.0},
+            (1, 2): {"flow": 8.0},
+            (1, 3): {"flow": 4.0},
+            (2, 3): {"flow": 11.0},
+            (2, "t"): {"flow": 5.0},
+            (3, "t"): {"flow": 10.0},
+        }
+        candidate2 = {
+            ("s", 1): {"flow": 12.0},
+            ("s", 2): {"flow": 8.0},
+            (1, 3): {"flow": 4.0},
+            (1, 2): {"flow": 8.0},
+            (2, 3): {"flow": 15.0},
+            (2, "t"): {"flow": 1.0},
+            (3, "t"): {"flow": 14.0},
+        }
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
 
@@ -259,7 +259,7 @@ class TestMinCostFlow3(unittest.TestCase):
             }
         ).set_index(["source", "target"])
 
-        self.assertTrue(check_solution_pandas(sol, [candidate]))
+        self.assertTrue(check_solution_pandas_multi(sol, [candidate]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
     def test_networkx(self):
@@ -277,4 +277,4 @@ class TestMinCostFlow3(unittest.TestCase):
             (3, 4, {"flow": 10.0}),
         ]
 
-        self.assertTrue(check_solution_networkx(sol, [candidate]))
+        self.assertTrue(check_solution_networkx_multi(sol, [candidate]))

--- a/tests/test_min_cost_flow.py
+++ b/tests/test_min_cost_flow.py
@@ -15,9 +15,7 @@ import gurobi_optimods.min_cost_flow as mcf
 
 from .test_graph_utils import (
     check_solution_networkx,
-    check_solution_networkx_multi,
     check_solution_pandas,
-    check_solution_pandas_multi,
     check_solution_scipy,
 )
 
@@ -93,7 +91,13 @@ class TestMinCostFlow(unittest.TestCase):
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
         sol = sol[sol > 0]
         self.assertEqual(cost, 31)
-        candidate = {(0, 1): 1.0, (0, 2): 1.0, (1, 3): 1.0, (2, 4): 2.0, (4, 5): 2.0}
+        candidate = [
+            ((0, 1), 1.0),
+            ((0, 2), 1.0),
+            ((1, 3), 1.0),
+            ((2, 4), 2.0),
+            ((4, 5), 2.0),
+        ]
         self.assertIsInstance(sol, pd.Series)
         self.assertTrue(check_solution_pandas(sol, [candidate]))
 
@@ -125,13 +129,13 @@ class TestMinCostFlow(unittest.TestCase):
         G = datasets.simple_graph_networkx()
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 31)
-        expected = {
-            (0, 1): {"flow": 1.0},
-            (0, 2): {"flow": 1.0},
-            (1, 3): {"flow": 1.0},
-            (2, 4): {"flow": 2.0},
-            (4, 5): {"flow": 2.0},
-        }
+        expected = [
+            ((0, 1), 1.0),
+            ((0, 2), 1.0),
+            ((1, 3), 1.0),
+            ((2, 4), 2.0),
+            ((4, 5), 2.0),
+        ]
         self.assertIsInstance(sol, nx.Graph)
         self.assertTrue(check_solution_networkx(sol, [expected]))
 
@@ -141,13 +145,13 @@ class TestMinCostFlow(unittest.TestCase):
         G = nx.relabel_nodes(G, {0: "s", 5: "t"})
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 31)
-        expected = {
-            ("s", 1): {"flow": 1.0},
-            ("s", 2): {"flow": 1.0},
-            (1, 3): {"flow": 1.0},
-            (2, 4): {"flow": 2.0},
-            (4, "t"): {"flow": 2.0},
-        }
+        expected = [
+            (("s", 1), 1.0),
+            (("s", 2), 1.0),
+            ((1, 3), 1.0),
+            ((2, 4), 2.0),
+            ((4, "t"), 2.0),
+        ]
         self.assertIsInstance(sol, nx.Graph)
         self.assertTrue(check_solution_networkx(sol, [expected]))
 
@@ -158,24 +162,24 @@ class TestMinCostFlow2(unittest.TestCase):
         cost, sol = mcf.min_cost_flow_pandas(edge_data, node_data)
         sol = sol[sol > 0]
         self.assertEqual(cost, 150)
-        candidate = {
-            (0, 1): 12.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 8.0,
-            (2, 3): 15.0,
-            (2, 4): 1.0,
-            (3, 4): 14.0,
-        }
-        candidate2 = {
-            (0, 1): 12.0,
-            (0, 2): 8.0,
-            (1, 3): 4.0,
-            (1, 2): 8.0,
-            (2, 3): 11.0,
-            (2, 4): 5.0,
-            (3, 4): 10.0,
-        }
+        candidate = [
+            ((0, 1), 12.0),
+            ((0, 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 8.0),
+            ((2, 3), 15.0),
+            ((2, 4), 1.0),
+            ((3, 4), 14.0),
+        ]
+        candidate2 = [
+            ((0, 1), 12.0),
+            ((0, 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 8.0),
+            ((2, 3), 11.0),
+            ((2, 4), 5.0),
+            ((3, 4), 10.0),
+        ]
         self.assertTrue(check_solution_pandas(sol, [candidate, candidate2]))
 
     def test_scipy(self):
@@ -197,24 +201,24 @@ class TestMinCostFlow2(unittest.TestCase):
         G = load_graph2_networkx()
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 150)
-        candidate = {
-            (0, 1): {"flow": 12.0},
-            (0, 2): {"flow": 8.0},
-            (1, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (2, 3): {"flow": 11.0},
-            (2, 4): {"flow": 5.0},
-            (3, 4): {"flow": 10.0},
-        }
-        candidate2 = {
-            (0, 1): {"flow": 12.0},
-            (0, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (1, 2): {"flow": 8.0},
-            (2, 3): {"flow": 15.0},
-            (2, 4): {"flow": 1.0},
-            (3, 4): {"flow": 14.0},
-        }
+        candidate = [
+            ((0, 1), 12.0),
+            ((0, 2), 8.0),
+            ((1, 2), 8.0),
+            ((1, 3), 4.0),
+            ((2, 3), 11.0),
+            ((2, 4), 5.0),
+            ((3, 4), 10.0),
+        ]
+        candidate2 = [
+            ((0, 1), 12.0),
+            ((0, 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 8.0),
+            ((2, 3), 15.0),
+            ((2, 4), 1.0),
+            ((3, 4), 14.0),
+        ]
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
@@ -223,23 +227,23 @@ class TestMinCostFlow2(unittest.TestCase):
         G = nx.relabel_nodes(G, {0: "s", 4: "t"})
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 150)
-        candidate = {
-            ("s", 1): {"flow": 12.0},
-            ("s", 2): {"flow": 8.0},
-            (1, 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (2, 3): {"flow": 11.0},
-            (2, "t"): {"flow": 5.0},
-            (3, "t"): {"flow": 10.0},
-        }
+        candidate = [
+            (("s", 1), 12.0),
+            (("s", 2), 8.0),
+            ((1, 2), 8.0),
+            ((1, 3), 4.0),
+            ((2, 3), 11.0),
+            ((2, "t"), 5.0),
+            ((3, "t"), 10.0),
+        ]
         candidate2 = {
-            ("s", 1): {"flow": 12.0},
-            ("s", 2): {"flow": 8.0},
-            (1, 3): {"flow": 4.0},
-            (1, 2): {"flow": 8.0},
-            (2, 3): {"flow": 15.0},
-            (2, "t"): {"flow": 1.0},
-            (3, "t"): {"flow": 14.0},
+            (("s", 1), 12.0),
+            (("s", 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 8.0),
+            ((2, 3), 15.0),
+            ((2, "t"), 1.0),
+            ((3, "t"), 14.0),
         }
         self.assertTrue(check_solution_networkx(sol, [candidate, candidate2]))
 
@@ -251,15 +255,17 @@ class TestMinCostFlow3(unittest.TestCase):
         sol = sol[sol > 0]
         self.assertEqual(cost, 49.0)
 
-        candidate = pd.DataFrame(
-            {
-                "source": [0, 0, 1, 1, 2, 2, 3, 2],
-                "target": [1, 2, 3, 2, 3, 4, 4, 3],
-                "flow": [12.0, 8.0, 4.0, 8.0, 10.0, 5.0, 10.0, 1.0],
-            }
-        ).set_index(["source", "target"])
-
-        self.assertTrue(check_solution_pandas_multi(sol, [candidate]))
+        candidate = [
+            ((0, 1), 12.0),
+            ((0, 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 8.0),
+            ((2, 3), 10.0),
+            ((2, 4), 5.0),
+            ((3, 4), 10.0),
+            ((2, 3), 1.0),
+        ]
+        self.assertTrue(check_solution_pandas(sol, [candidate]))
 
     @unittest.skipIf(nx is None, "networkx is not installed")
     def test_networkx(self):
@@ -267,14 +273,14 @@ class TestMinCostFlow3(unittest.TestCase):
         cost, sol = mcf.min_cost_flow_networkx(G)
         self.assertEqual(cost, 49.0)
         candidate = [
-            (0, 1, {"flow": 12.0}),
-            (0, 2, {"flow": 8.0}),
-            (1, 3, {"flow": 4.0}),
-            (1, 2, {"flow": 8.0}),
-            (2, 3, {"flow": 10.0}),
-            (2, 3, {"flow": 1.0}),
-            (2, 4, {"flow": 5.0}),
-            (3, 4, {"flow": 10.0}),
+            ((0, 1), 12.0),
+            ((0, 2), 8.0),
+            ((1, 3), 4.0),
+            ((1, 2), 8.0),
+            ((2, 3), 10.0),
+            ((2, 3), 1.0),
+            ((2, 4), 5.0),
+            ((3, 4), 10.0),
         ]
 
-        self.assertTrue(check_solution_networkx_multi(sol, [candidate]))
+        self.assertTrue(check_solution_networkx(sol, [candidate]))


### PR DESCRIPTION
Enable multiple edges in the same direction between two nodes

### Description
Currently the solver does not support multiple edges of between two nodes in the same direction. This PR implements this feature for pandas and networkx. 

scipy, because of the matrix representation, requires some more complex changes to support it. For now this is left out as it is somewhat obvious to the user that this would not be supported for this structure.

fixes #155 

Implements based on feedback from #156 

### Checklist

- Implementation:
  - [x] Implementation of the Mod in the `gurobi_optimods` installable package
  - [x] Tests for the Mod implementation in `tests/`
  - [x] Docstrings for public API, correctly linked using sphinx-autodoc
- Documentation page:
  - [x] Background and problem specification
  - [x] Example of the input data format (use `gurobi_optimods.datasets` for loading data)
  - [x] Runnable code example
  - [x] Presentation of solutions
  - [x] Included in the mod gallery and toctree
