### PR TITLE
Setting PStart on branch switching variables

### DIFF
--- a/src/gurobi_optimods/opf/grbformulator.py
+++ b/src/gurobi_optimods/opf/grbformulator.py
@@ -108,6 +108,13 @@ def lpformulator_optimize(alldata, model, opftype):
         for j in range(1, 1 + numbuses):
             bus = buses[j]
             evar[bus].PStart = 1.0
+        if alldata["branchswitching_mip"]:
+            zvar = alldata["MIP"]["zvar"]
+            branches = alldata["branches"]
+            numbranches = alldata["numbranches"]
+            for j in range(1, 1 + numbranches):
+                branch = branches[j]
+                zvar[branch].PStart = 1.0
         model.update()
     model.optimize()
 

--- a/src/gurobi_optimods/opf/grbformulator.py
+++ b/src/gurobi_optimods/opf/grbformulator.py
@@ -109,12 +109,8 @@ def lpformulator_optimize(alldata, model, opftype):
             bus = buses[j]
             evar[bus].PStart = 1.0
         if alldata["branchswitching_mip"]:
-            zvar = alldata["MIP"]["zvar"]
-            branches = alldata["branches"]
-            numbranches = alldata["numbranches"]
-            for j in range(1, 1 + numbranches):
-                branch = branches[j]
-                zvar[branch].PStart = 1.0
+            for zvar in alldata["MIP"]["zvar"].values():
+                zvar.PStart = 1.0
         model.update()
     model.optimize()
 


### PR DESCRIPTION
### Description
When branch switching is set to 1 (`branch_switching=True`) we do not set the `PStart` to 1 for the binary variables and therefore we miss to find the easy incumbent where all lines are on.