### PR TITLE
numpy<2 restriction removed

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,8 +91,12 @@ numpydoc_xref_ignore = {"optional", "or", "of"}
 
 # -- doctest configuration
 
+# will need to update rst docs if not using legacy numpy print option
 doctest_global_setup = """
 def size_limited_license():
+
+    import numpy as np
+    np.set_printoptions(legacy='1.25')
 
     result = False
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,9 +95,6 @@ numpydoc_xref_ignore = {"optional", "or", "of"}
 doctest_global_setup = """
 def size_limited_license():
 
-    import numpy as np
-    np.set_printoptions(legacy='1.25')
-
     result = False
 
     try:
@@ -112,6 +109,9 @@ def size_limited_license():
             result = True
 
     return result
+
+import numpy as np
+np.set_printoptions(legacy='1.25')
 """
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
 ]
 dependencies = [
     "gurobipy[matrixapi]>=10.0.3",
     "gurobipy-pandas>=1.0.0",
-    "numpy<2",
+    "numpy",
     "pandas",
     "scipy>=1.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "gurobipy[matrixapi]>=10.0.3",
+    "gurobipy[matrixapi]>=11.0.0",
     "gurobipy-pandas>=1.0.0",
     "numpy",
     "pandas",

--- a/src/gurobi_optimods/portfolio.py
+++ b/src/gurobi_optimods/portfolio.py
@@ -172,7 +172,8 @@ class MeanVariancePortfolio:
         initial_holdings = self._homogenize_input(initial_holdings)
 
         if initial_holdings is not None:
-            if initial_holdings.sum() > 1.0:
+            sum_initial_holding = initial_holdings.sum()
+            if sum_initial_holding > 1.0 and not np.isclose(sum_initial_holding, 1):
                 raise ValueError("Initial holding's sum must not exceed 1.0")
         else:
             initial_holdings = np.zeros(self._mu.shape)

--- a/src/gurobi_optimods/portfolio.py
+++ b/src/gurobi_optimods/portfolio.py
@@ -172,8 +172,8 @@ class MeanVariancePortfolio:
         initial_holdings = self._homogenize_input(initial_holdings)
 
         if initial_holdings is not None:
-            sum_initial_holding = initial_holdings.sum()
-            if sum_initial_holding > 1.0 and not np.isclose(sum_initial_holding, 1):
+            # Need a slight tolerance for accumulated sum error
+            if initial_holdings.sum() > 1.0 + 1e-10:
                 raise ValueError("Initial holding's sum must not exceed 1.0")
         else:
             initial_holdings = np.zeros(self._mu.shape)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py38,py39,py310,py311,py312,py313
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
### Description
Fixes #173 

Code tests are passing, even when I force numpy >= 2, but doctests are failing

I had to change the condition on an assert statement to accommodate small errors, i.e. use np.isclose, in order for tests to pass