### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,13 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.9", "3.13"]
+        python: ["3.10", "3.13"]
         gurobipy: ["~=11.0", "~=12.0", "==13.0.0b1"]
         exclude:
           - python: "3.13"
             gurobipy: "~=11.0"
-          - python: "3.9"
-            gurobipy: "==13.0.0b1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheel-tests.yml
+++ b/.github/workflows/wheel-tests.yml
@@ -18,13 +18,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
         gurobipy: ["~=11.0", "~=12.0", "==13.0.0b1"]
         exclude:
           - python: "3.13"
             gurobipy: "~=11.0"
-          - python: "3.9"
-            gurobipy: "==13.0.0b1"
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "gurobi-optimods"
 description = "Data-driven APIs for common optimization tasks"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 keywords = ["optimization", "gurobipy", "pandas", "scipy"]
 authors = [
@@ -16,7 +16,6 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Python3.9 has reached end of life. Update tests workflows and minimum required python version for the package.