### PR TITLE
Use default parameters for global ACOPF models

### DIFF
--- a/src/gurobi_optimods/opf/api.py
+++ b/src/gurobi_optimods/opf/api.py
@@ -118,21 +118,21 @@ def solve_opf(
         useef = True
         usejabr = True
         polar = False
-        default_solver_params = {"MIPGap": 1e-3, "OptimalityTol": 1e-3}
+        default_solver_params = {}
     # Exact polar AC
     elif opftype.lower() == "acpglobal":
         opftype = "ac"
         useef = False
         usejabr = False
         polar = True
-        default_solver_params = {"MIPGap": 1e-3, "OptimalityTol": 1e-3}
+        default_solver_params = {}
     # AC relaxation using the JABR inequality
     elif opftype.lower() == "acrelax":
         opftype = "ac"
         useef = False
         usejabr = True
         polar = False
-        default_solver_params = {"MIPGap": 1e-3, "OptimalityTol": 1e-3}
+        default_solver_params = {}
     # DC linear approximation (ef & jabr are irrelevant)
     elif opftype.lower() == "dc":
         opftype = "dc"

--- a/tests/opf/test_solver.py
+++ b/tests/opf/test_solver.py
@@ -4,6 +4,8 @@ import collections
 import math
 import random
 import unittest
+from contextlib import nullcontext
+from unittest.mock import patch
 
 from gurobipy import GRB
 
@@ -11,6 +13,21 @@ from gurobi_optimods.datasets import load_opf_example
 from gurobi_optimods.opf import solve_opf
 
 from ..utils import size_limited_license
+
+
+class TestDefaultSolverParameters(unittest.TestCase):
+    def test_global_ac_models_use_gurobi_defaults(self):
+        captured_params = []
+
+        def capture_params(params=None):
+            captured_params.append(params)
+            return nullcontext()
+
+        with patch("gurobi_optimods.opf.api._solve_opf_model_internal"):
+            for opftype in ("ACRGLOBAL", "ACPGLOBAL", "ACRELAX"):
+                solve_opf.__wrapped__({}, opftype=opftype, create_env=capture_params)
+
+        self.assertEqual(captured_params, [{}, {}, {}])
 
 
 class TestInvalidData(unittest.TestCase):


### PR DESCRIPTION
Closes #171.

The global rectangular AC, global polar AC, and AC relaxation variants now leave `MIPGap` and `OptimalityTol` at their Gurobi defaults. Local AC solver parameters and the existing DC settings are unchanged.

A focused regression intercepts environment creation for all three affected variants and verifies that no model-specific solver parameters are injected.

Checks run locally:
- `python -m unittest tests.opf.test_solver -v` (40 tests passed, 13 skipped)
- focused default-parameter regression
- `pre-commit run --all-files`
- `git diff --check`